### PR TITLE
Resolve the issue of Xorg crashing remove displaylink devices.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xorg-server (2:21.1.10-1deepin3) UNRELEASED; urgency=medium
+
+  * Resolve the issue of Xorg crashing remove displaylink devices.
+
+ -- huxiaodong <huxiaodong@uniontech.com>  Fri, 18 Oct 2024 08:57:24 +0800
+
 xorg-server (2:21.1.10-1deepin2) unstable; urgency=medium
 
   * Xrecord add touch support.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-xorg-server (2:21.1.10-1deepin3) UNRELEASED; urgency=medium
+xorg-server (2:21.1.10-1deepin3) unstable; urgency=medium
 
   * Resolve the issue of Xorg crashing remove displaylink devices.
 

--- a/debian/patches/Resolve_xorg_crashing_whith_displaylink_unplugging.patch
+++ b/debian/patches/Resolve_xorg_crashing_whith_displaylink_unplugging.patch
@@ -1,0 +1,14 @@
+diff --git a/hw/xfree86/common/xf86DGA.c b/hw/xfree86/common/xf86DGA.c
+index fa70ba2..b38b30f 100644
+--- a/hw/xfree86/common/xf86DGA.c
++++ b/hw/xfree86/common/xf86DGA.c
+@@ -268,7 +268,8 @@ DGACloseScreen(ScreenPtr pScreen)
+     DGAScreenPtr pScreenPriv = DGA_GET_SCREEN_PRIV(pScreen);
+ 
+     mieqSetHandler(ET_DGAEvent, NULL);
+-    pScreenPriv->pScrn->SetDGAMode(pScreenPriv->pScrn, 0, NULL);
++    if (pScreenPriv->pScrn->SetDGAMode)
++        pScreenPriv->pScrn->SetDGAMode(pScreenPriv->pScrn, 0, NULL);
+     FreeMarkedVisuals(pScreen);
+ 
+     pScreen->CloseScreen = pScreenPriv->CloseScreen;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -7,3 +7,4 @@
 07_use-modesetting-driver-by-default-on-GeForce.diff
 add-device-id.patch
 feat-Xrecord-add-touch-support.patch
+Resolve_xorg_crashing_whith_displaylink_unplugging.patch


### PR DESCRIPTION
Log: Resolve the issue of Xorg crashing remove displaylink devices.

Bug: https://pms.uniontech.com/bug-view-276287.html