### PR TITLE
fix: mips64el no bootvga

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xorg-server (2:21.1.10-1deepin5) unstable; urgency=medium
+
+  * fix mips64el no bootvga. 
+
+ -- lichenggang <lichenggang@deepin.org>  Thu, 20 Feb 2025 11:13:04 +0800
+
 xorg-server (2:21.1.10-1deepin4) unstable; urgency=medium
   * form 21.0.14	
   * New upstream release

--- a/debian/patches/0001-fix-mips64el-no-bootvga.patch
+++ b/debian/patches/0001-fix-mips64el-no-bootvga.patch
@@ -1,0 +1,34 @@
+From 8b2eff620ec8db1f6c48862a33ae86cb33bcd625 Mon Sep 17 00:00:00 2001
+From: lichenggang <lichenggang@deepin.org>
+Date: Thu, 20 Feb 2025 11:09:32 +0800
+Subject: [PATCH] fix: mips64el no bootvga
+
+---
+ hw/xfree86/common/xf86Bus.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/hw/xfree86/common/xf86Bus.c b/hw/xfree86/common/xf86Bus.c
+index fd144db..3ebd46a 100644
+--- a/hw/xfree86/common/xf86Bus.c
++++ b/hw/xfree86/common/xf86Bus.c
+@@ -241,6 +241,7 @@ xf86BusProbe(void)
+ {
+ #ifdef XSERVER_PLATFORM_BUS
+     xf86platformProbe();
++    xf86platformPrimary();
+     if (ServerIsNotSeat0() && xf86_num_platform_devices > 0)
+         return;
+ #endif
+@@ -250,9 +251,6 @@ xf86BusProbe(void)
+ #if (defined(__sparc__) || defined(__sparc)) && !defined(__OpenBSD__)
+     xf86SbusProbe();
+ #endif
+-#ifdef XSERVER_PLATFORM_BUS
+-    xf86platformPrimary();
+-#endif
+ }
+ 
+ /*
+-- 
+2.45.2
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -10,3 +10,4 @@
 add-device-id.patch
 feat-Xrecord-add-touch-support.patch
 Resolve_xorg_crashing_whith_displaylink_unplugging.patch
+0001-fix-mips64el-no-bootvga.patch


### PR DESCRIPTION
解决mips64el 架构设备上 xorg无法找到正确的主显示设备问题