### PR TITLE
fix: backport fixes for gles and imggpu

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+xorg-server (2:21.1.10-1deepin9) unstable; urgency=medium
+
+  * glamor: GLES fixes, part 1
+    (https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1007)
+  * glamor: add gl_PointSize for ES shaders
+    (https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1156)
+  * glamor: handle EXT_gpu_shader4 in dual source blend paths
+    (https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1066)
+  * glamor: supports GLES3 shaders
+    (https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/948)
+  * glamor: Don't require EXT_gpu_shader4 unconditionally (fix previous MR)
+    (https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1179)
+  * glamor: Fix dual blend on GLES3 (fix for PowerVR driver)
+    (https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1750)
+
+ -- Chang Yang <yangchang@deepin.org>  Fri, 27 Jun 2025 17:08:29 +0800
+
 xorg-server (2:21.1.10-1deepin8) unstable; urgency=medium
 
   * feat: add glenfly arise device id

--- a/debian/patches/glamor-gles/1000-glamor-GLES-fixes-part-1.patch
+++ b/debian/patches/glamor-gles/1000-glamor-GLES-fixes-part-1.patch
@@ -1,0 +1,901 @@
+From ddcd4846d1fa8c408733f4435a52344d3eab850e Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Sat, 25 Jun 2022 21:58:08 +0300
+Subject: [PATCH 1/6] meson: add glamor gles2 tests
+
+Signed-off-by: Konstantin Pugin <ria.freelander@gmail.com>
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Reviewed-by: Emma Anholt <emma@anholt.net>
+---
+ test/bugs/bug1354.c                        | 149 +++++++++++++++++++++
+ test/bugs/meson.build                      |  51 +++++++
+ test/meson.build                           |  58 +++++++-
+ test/scripts/xephyr-glamor-gles2-piglit.sh |  34 +++++
+ 4 files changed, 287 insertions(+), 5 deletions(-)
+ create mode 100644 test/bugs/bug1354.c
+ create mode 100644 test/bugs/meson.build
+ create mode 100755 test/scripts/xephyr-glamor-gles2-piglit.sh
+
+diff --git a/test/bugs/bug1354.c b/test/bugs/bug1354.c
+new file mode 100644
+index 0000000000..edc3f228c2
+--- /dev/null
++++ b/test/bugs/bug1354.c
+@@ -0,0 +1,149 @@
++#include <xcb/xcb.h>
++#include <xcb/xcb_aux.h>
++#include <xcb/xcb_image.h>
++#include <stdint.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <getopt.h>
++#include <ctype.h>
++#include <unistd.h>
++
++/*
++ * This is a test which try to test correct glamor colors when rendered.
++ * It should be run with fullscreen Xephyr (with glamor) with present and with 
++ * etalon high-level Xserver (can be any, on CI - Xvfb). For testing this test
++ * creates an image in Xephyr X server, which filled by one of colors defined in
++ * test_pixels. Then it captures central pixel from both Xephyr and Xserver above.
++ * If pixels differ - test failed. Sleep is used to ensure than presentation on both 
++ * Xephyr and Xvfb kicks (xcb_aux_sync was not enough) and test results will be actual
++ */
++
++#define WIDTH 300
++#define HEIGHT 300
++
++int get_display_pixel(xcb_connection_t* c, xcb_drawable_t win);
++void draw_display_pixel(xcb_connection_t* c, xcb_drawable_t win, uint32_t pixel_color);
++
++int get_display_pixel(xcb_connection_t* c, xcb_drawable_t win)
++{
++	xcb_image_t *image;
++	uint32_t    pixel;
++	int format = XCB_IMAGE_FORMAT_XY_PIXMAP;
++
++	image = xcb_image_get (c, win,
++		 0, 0, WIDTH, HEIGHT,
++		 UINT32_MAX,
++		 format);
++	if (!image) {
++	  printf("xcb_image_get failed: exiting\n");
++	  exit(1);
++	}
++
++	pixel = xcb_image_get_pixel(image, WIDTH/2, HEIGHT/2);
++
++	return pixel;
++}
++
++void draw_display_pixel(xcb_connection_t* c, xcb_drawable_t win, uint32_t pixel_color)
++{
++	xcb_gcontext_t       foreground;
++	uint32_t             mask = 0;
++
++	xcb_rectangle_t rectangles[] = {
++	  {0, 0, WIDTH, HEIGHT},
++	};
++
++	foreground = xcb_generate_id (c);
++	mask = XCB_GC_FOREGROUND | XCB_GC_LINE_WIDTH | XCB_GC_SUBWINDOW_MODE;
++
++	uint32_t values[] = {
++		pixel_color,
++		20,
++		XCB_SUBWINDOW_MODE_INCLUDE_INFERIORS
++	};
++
++	xcb_create_gc (c, foreground, win, mask, values);
++
++	xcb_poly_fill_rectangle (c, win, foreground, 1, rectangles);
++	xcb_aux_sync ( c );
++}
++
++
++int main(int argc, char* argv[])
++{
++	xcb_connection_t    *c, *r;
++	xcb_screen_t        *screen1, *screen2;
++	xcb_drawable_t       win1, win2;
++    char *name_test = NULL, *name_relevant = NULL;
++	uint32_t pixel_server1, pixel_server2;
++	int result = 0;
++	uint32_t test_pixels[3] = {0xff0000, 0x00ff00, 0x0000ff};
++	int gv;
++
++	while ((gv = getopt (argc, argv, "t:r:")) != -1)
++	switch (gv)
++	  {
++	  case 't':
++		name_test = optarg;
++		break;
++	  case 'r':
++		name_relevant = optarg;
++		break;
++	  case '?':
++		if (optopt == 't' || optopt == 'r')
++		  fprintf (stderr, "Option -%c requires an argument - test screen name.\n", optopt);
++		else if (isprint (optopt))
++		  fprintf (stderr, "Unknown option `-%c'.\n", optopt);
++		else
++		  fprintf (stderr,
++		           "Unknown option character `\\x%x'.\n",
++		           optopt);
++		return 1;
++	  default:
++		abort ();
++	  }
++
++	printf("test=%s, rel=%s\n", name_test, name_relevant);
++
++	c = xcb_connect (name_test, NULL);
++	r = xcb_connect (name_relevant, NULL);
++
++	/* get the first screen */
++	screen1 = xcb_setup_roots_iterator (xcb_get_setup (c)).data;
++
++    win1 = xcb_generate_id (c);
++    xcb_create_window (c,                    /* Connection          */
++                       XCB_COPY_FROM_PARENT,          /* depth (same as root)*/
++                       win1,                        /* window Id           */
++                       screen1->root,                  /* parent window       */
++                       0, 0,                          /* x, y                */
++                       WIDTH, HEIGHT,                /* width, height       */
++                       20,                            /* border_width        */
++                       XCB_WINDOW_CLASS_INPUT_OUTPUT, /* class               */
++                       screen1->root_visual,           /* visual              */
++                       0, NULL );                     /* masks, not used yet */
++
++
++    /* Map the window on the screen */
++    xcb_map_window (c, win1);
++    xcb_aux_sync(c);
++
++	/* get the first screen */
++	screen2 = xcb_setup_roots_iterator (xcb_get_setup (r)).data;
++
++	/* root window */
++	win2 = screen2->root;
++
++	for(int i = 0; i < 3; i++)
++	{
++		draw_display_pixel(c, win1, test_pixels[i]);
++		xcb_aux_sync(r);
++		pixel_server1 = get_display_pixel(c, win1);
++		sleep(1);
++		pixel_server2 = get_display_pixel(r, win2);
++		xcb_aux_sync(r);
++		printf("p=0x%x, p2=0x%x\n", pixel_server1, pixel_server2);
++		result+= pixel_server1 == pixel_server2;
++	}
++	return result == 3 ? 0 : 1;
++}
+diff --git a/test/bugs/meson.build b/test/bugs/meson.build
+new file mode 100644
+index 0000000000..1f5305f56f
+--- /dev/null
++++ b/test/bugs/meson.build
+@@ -0,0 +1,51 @@
++xcb_dep = dependency('xcb', required: false)
++xcb_image_dep = dependency('xcb-image', required: false)
++xcb_util_dep = dependency('xcb-util', required: false)
++
++if get_option('xvfb')
++    xvfb_args = [
++        xvfb_server.full_path(),
++        '-screen',
++        'scrn',
++        '1280x1024x24'
++    ]
++
++    if xcb_dep.found() and xcb_image_dep.found() and xcb_util_dep.found() and get_option('xvfb') and get_option('xephyr') and build_glamor
++        bug1354 = executable('bug1354', 'bug1354.c', dependencies: [xcb_dep, xcb_image_dep, xcb_util_dep])
++        test('bug1354-gl',
++                simple_xinit,
++                args: [simple_xinit.full_path(),
++                    bug1354.full_path(),
++                    '-t',':201','-r',':200',
++                    '----',
++                    xephyr_server.full_path(),
++                    '-glamor',
++                    '-schedMax', '2000',
++                    ':201',
++                    '--',
++                    xvfb_args,
++                    ':200'
++                    ],
++                suite: 'xephyr-glamor',
++                timeout: 300,
++            )
++        test('bug1354-gles',
++                simple_xinit,
++                args: [simple_xinit.full_path(),
++                    bug1354.full_path(),
++                    '-t',':199','-r',':198',
++                    '----',
++                    xephyr_server.full_path(),
++                    '-glamor_gles2',
++                    '-schedMax', '2000',
++                    ':199',
++                    '--',
++                    xvfb_args,
++                    ':198'
++                    ],
++                suite: 'xephyr-glamor-gles2',
++                timeout: 300,
++                should_fail: true,
++            )
++    endif
++endif
+\ No newline at end of file
+diff --git a/test/meson.build b/test/meson.build
+index a8d9e84973..662eee4ef3 100644
+--- a/test/meson.build
++++ b/test/meson.build
+@@ -9,13 +9,24 @@ piglit_env.set('XSERVER_DIR', meson.source_root())
+ piglit_env.set('XSERVER_BUILDDIR', meson.build_root())
+ 
+ some_ops = ' -o clear,src,dst,over,xor,disjointover'
+-rendercheck_tests = [
++gles2_working_formats = ' -f '+ ','.join(['a8',
++                                          'a8r8g8b8',
++                                          'x8r8g8b8',
++                                          'b8g8r8a8',
++                                          'b8g8r8x8',
++                                          'r8g8b8',
++                                          'r5g5b5',
++                                          'b5g5r5',
++                                          'r5g6b5',
++                                          'b5g6r5',
++                                          'b8g8r8',
++                                          'x8b8g8r8',
++                                          'x2r10g10b10',
++                                          'x2b10g10r10'])
++rendercheck_tests_noblend = [
+     ['blend/All/a8r8g8b8', '-t blend -f a8r8g8b8'],
+     ['blend/All/x8r8g8b8', '-t blend -f a8r8g8b8,x8r8g8b8'],
+     ['blend/All/a2r10g10b10', '-t blend -f a8r8g8b8,a2r10g10b10'],
+-    ['blend/Clear', '-t blend -o clear'],
+-    ['blend/Src', '-t blend -o src'],
+-    ['blend/Over', '-t blend -o over'],
+     ['composite/Some/a8r8g8b8', '-t composite -f a8r8g8b8' + some_ops],
+     ['composite/Some/x8r8g8b8', '-t composite -f a8r8g8b8,x8r8g8b8' + some_ops],
+     ['composite/Some/a2r10g10b10', '-t composite -f a8r8g8b8,a2r10g10b10' + some_ops],
+@@ -34,7 +45,19 @@ rendercheck_tests = [
+     ['LibreOffice xRGB', '-t libreoffice_xrgb'],
+     ['GTK ARGB vs xBGR', '-t gtk_argb_xbgr'],
+ ]
+-
++rendercheck_blend = [
++    ['blend/Clear', '-t blend -o clear'],
++    ['blend/Src', '-t blend -o src'],
++    ['blend/Over', '-t blend -o over'],
++]
++#Exclude 15bpp for now due to GLES limitation (see glamor.c:470)
++rendercheck_blend_gles2 = [
++    ['blend/Clear', '-t blend -o clear' + gles2_working_formats],
++    ['blend/Src', '-t blend -o src' + gles2_working_formats],
++    ['blend/Over', '-t blend -o over' + gles2_working_formats],
++]
++rendercheck_tests = rendercheck_blend + rendercheck_tests_noblend
++rendercheck_tests_gles2 = rendercheck_blend_gles2 + rendercheck_tests_noblend
+ rendercheck = find_program('rendercheck', required:false)
+ 
+ if get_option('xvfb')
+@@ -76,6 +99,12 @@ if get_option('xvfb')
+             timeout: 1200,
+             suite: 'xephyr-glamor',
+         )
++        test('XTS',
++            find_program('scripts/xephyr-glamor-gles2-piglit.sh'),
++            env: piglit_env,
++            timeout: 1200,
++            suite: 'xephyr-glamor-gles2',
++        )
+ 
+         if rendercheck.found()
+             foreach rctest: rendercheck_tests
+@@ -96,6 +125,24 @@ if get_option('xvfb')
+                      timeout: 300,
+                     )
+             endforeach
++            foreach rctest: rendercheck_tests_gles2
++                test(rctest[0],
++                     simple_xinit,
++                     args: [simple_xinit.full_path(),
++                            rendercheck.path(),
++                            rctest[1].split(' '),
++                            '----',
++                            xephyr_server.full_path(),
++                            '-glamor_gles2',
++                            '-glamor-skip-present',
++                            '-schedMax', '2000',
++                            '--',
++                            xvfb_args,
++                           ],
++                     suite: 'xephyr-glamor-gles2',
++                     timeout: 300,
++                    )
++            endforeach
+         endif
+     endif
+ endif
+@@ -116,6 +163,7 @@ endif
+ subdir('bigreq')
+ subdir('damage')
+ subdir('sync')
++subdir('bugs')
+ 
+ if build_xorg
+ # Tests that require at least some DDX functions in order to fully link
+diff --git a/test/scripts/xephyr-glamor-gles2-piglit.sh b/test/scripts/xephyr-glamor-gles2-piglit.sh
+new file mode 100755
+index 0000000000..59ca12d263
+--- /dev/null
++++ b/test/scripts/xephyr-glamor-gles2-piglit.sh
+@@ -0,0 +1,34 @@
++#!/bin/sh
++
++# this times out on Travis, because the tests take too long.
++if test "x$TRAVIS_BUILD_DIR" != "x"; then
++    exit 77
++fi
++
++# Start a Xephyr server using glamor.  Since the test environment is
++# headless, we start an Xvfb first to host the Xephyr.
++export PIGLIT_RESULTS_DIR=$XSERVER_BUILDDIR/test/piglit-results/xephyr-glamor-gles2
++
++export SERVER_COMMAND="$XSERVER_BUILDDIR/hw/kdrive/ephyr/Xephyr \
++        -glamor_gles2 \
++        -glamor-skip-present \
++        -noreset \
++        -schedMax 2000 \
++        -screen 1280x1024"
++
++# Tests that currently fail on llvmpipe on CI
++PIGLIT_ARGS="$PIGLIT_ARGS -x xcleararea@6"
++PIGLIT_ARGS="$PIGLIT_ARGS -x xcleararea@7"
++PIGLIT_ARGS="$PIGLIT_ARGS -x xclearwindow@4"
++PIGLIT_ARGS="$PIGLIT_ARGS -x xclearwindow@5"
++PIGLIT_ARGS="$PIGLIT_ARGS -x xcopyarea@1"
++PIGLIT_ARGS="$PIGLIT_ARGS -x xsetfontpath@1"
++PIGLIT_ARGS="$PIGLIT_ARGS -x xsetfontpath@2"
++
++export PIGLIT_ARGS
++
++$XSERVER_BUILDDIR/test/simple-xinit \
++        $XSERVER_DIR/test/scripts/run-piglit.sh \
++        -- \
++        $XSERVER_BUILDDIR/hw/vfb/Xvfb \
++        -screen scrn 1280x1024x24
+-- 
+GitLab
+
+
+From 24cd5f34f8edcc6621ed9c0f2b1a3df08de7488d Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Sun, 26 Jun 2022 00:01:54 +0300
+Subject: [PATCH 2/6] glamor: make use of GL_EXT_texture_format_BGRA8888
+
+For 24 and 32 bit depth pictures xserver uses PICT_x8r8g8b8 and PICT_a8r8g8b8 formats,
+which must be backed with GL_BGRA format. It is present in OpenGL ES 2.0 only with
+GL_EXT_texture_format_BGRA8888 extension. We require such extension in glamor_init,
+so, why not to make use of it?
+Fixes #1208
+Fixes #1354
+
+Signed-off-by: Konstantin Pugin <ria.freelander@gmail.com>
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Reviewed-by: Emma Anholt <emma@anholt.net>
+---
+ glamor/glamor.c         | 8 ++++----
+ glamor/glamor_picture.c | 7 ++-----
+ test/bugs/meson.build   | 1 -
+ 3 files changed, 6 insertions(+), 10 deletions(-)
+
+diff --git a/test/bugs/meson.build b/test/bugs/meson.build
+index 1f5305f56f..470706d565 100644
+--- a/test/bugs/meson.build
++++ b/test/bugs/meson.build
+@@ -45,7 +45,6 @@ if get_option('xvfb')
+                     ],
+                 suite: 'xephyr-glamor-gles2',
+                 timeout: 300,
+-                should_fail: true,
+             )
+     endif
+ endif
+\ No newline at end of file
+-- 
+GitLab
+
+
+From a59531533fb8fd137d21e0578909d8e91c28dff6 Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Sat, 25 Jun 2022 17:51:15 +0300
+Subject: [PATCH 3/6] glamor: transpose gradients transparently
+
+glUniformMatrix3fv is used with argument transpose set to GL_TRUE.
+According to the Khronos OpenGL ES 2.0 pages transpose must be GL_FALSE.
+Actually we can just return transformed matrix from
+_glamor_gradient_convert_trans_matrix (@anholt suggest),
+so @uvas workaround is not required
+
+Signed-off-by: Konstantin Pugin <ria.freelander@gmail.com>
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Reviewed-by: Emma Anholt <emma@anholt.net>
+---
+ glamor/glamor_gradient.c | 32 +++++++++++++++++++++-----------
+ 1 file changed, 21 insertions(+), 11 deletions(-)
+
+diff --git a/glamor/glamor_gradient.c b/glamor/glamor_gradient.c
+index 7e5d5cca9f..4c7ae4d77c 100644
+--- a/glamor/glamor_gradient.c
++++ b/glamor/glamor_gradient.c
+@@ -605,27 +605,35 @@ _glamor_gradient_convert_trans_matrix(PictTransform *from, float to[3][3],
+      * T_s = | w*t21/h  t22      t23/h|
+      *       | w*t31    h*t32    t33  |
+      *       --                      --
++     *
++     * Because GLES2 cannot do trasposed mat by spec, we did transposing inside this function
++     * already, and matrix becoming look like this:
++     *       --                      --
++     *       | t11      w*t21/h  t31*w|
++     * T_s = | h*t12/w  t22      t32*h|
++     *       | t13/w    t23/h    t33  |
++     *       --                      --
+      */
+ 
+     to[0][0] = (float) pixman_fixed_to_double(from->matrix[0][0]);
+-    to[0][1] = (float) pixman_fixed_to_double(from->matrix[0][1])
++    to[1][0] = (float) pixman_fixed_to_double(from->matrix[0][1])
+         * (normalize ? (((float) height) / ((float) width)) : 1.0);
+-    to[0][2] = (float) pixman_fixed_to_double(from->matrix[0][2])
++    to[2][0] = (float) pixman_fixed_to_double(from->matrix[0][2])
+         / (normalize ? ((float) width) : 1.0);
+ 
+-    to[1][0] = (float) pixman_fixed_to_double(from->matrix[1][0])
++    to[0][1] = (float) pixman_fixed_to_double(from->matrix[1][0])
+         * (normalize ? (((float) width) / ((float) height)) : 1.0);
+     to[1][1] = (float) pixman_fixed_to_double(from->matrix[1][1]);
+-    to[1][2] = (float) pixman_fixed_to_double(from->matrix[1][2])
++    to[2][1] = (float) pixman_fixed_to_double(from->matrix[1][2])
+         / (normalize ? ((float) height) : 1.0);
+ 
+-    to[2][0] = (float) pixman_fixed_to_double(from->matrix[2][0])
++    to[0][2] = (float) pixman_fixed_to_double(from->matrix[2][0])
+         * (normalize ? ((float) width) : 1.0);
+-    to[2][1] = (float) pixman_fixed_to_double(from->matrix[2][1])
++    to[1][2] = (float) pixman_fixed_to_double(from->matrix[2][1])
+         * (normalize ? ((float) height) : 1.0);
+     to[2][2] = (float) pixman_fixed_to_double(from->matrix[2][2]);
+ 
+-    DEBUGF("the transform matrix is:\n%f\t%f\t%f\n%f\t%f\t%f\n%f\t%f\t%f\n",
++    DEBUGF("the transposed transform matrix is:\n%f\t%f\t%f\n%f\t%f\t%f\n%f\t%f\t%f\n",
+            to[0][0], to[0][1], to[0][2],
+            to[1][0], to[1][1], to[1][2], to[2][0], to[2][1], to[2][2]);
+ }
+@@ -950,11 +958,12 @@ glamor_generate_radial_gradient_picture(ScreenPtr screen,
+         _glamor_gradient_convert_trans_matrix(src_picture->transform,
+                                               transform_mat, width, height, 0);
+         glUniformMatrix3fv(transform_mat_uniform_location,
+-                           1, 1, &transform_mat[0][0]);
++                           1, GL_FALSE, &transform_mat[0][0]);
+     }
+     else {
++        /* identity matrix dont need to be transposed */
+         glUniformMatrix3fv(transform_mat_uniform_location,
+-                           1, 1, &identity_mat[0][0]);
++                           1, GL_FALSE, &identity_mat[0][0]);
+     }
+ 
+     if (!_glamor_gradient_set_pixmap_destination
+@@ -1266,11 +1275,12 @@ glamor_generate_linear_gradient_picture(ScreenPtr screen,
+         _glamor_gradient_convert_trans_matrix(src_picture->transform,
+                                               transform_mat, width, height, 1);
+         glUniformMatrix3fv(transform_mat_uniform_location,
+-                           1, 1, &transform_mat[0][0]);
++                           1, GL_FALSE, &transform_mat[0][0]);
+     }
+     else {
++        /* identity matrix dont need to be transposed */
+         glUniformMatrix3fv(transform_mat_uniform_location,
+-                           1, 1, &identity_mat[0][0]);
++                           1, GL_FALSE, &identity_mat[0][0]);
+     }
+ 
+     if (!_glamor_gradient_set_pixmap_destination
+-- 
+GitLab
+
+
+From 65392d27d77fbdb66e874ba3e2d85dbcf46e4583 Mon Sep 17 00:00:00 2001
+From: Yuriy <uuvasiliev@yandex.ru>
+Date: Thu, 16 Sep 2021 14:47:44 +0300
+Subject: [PATCH 4/6] glamor: fix CbCr format handling
+
+In GLES2, we cannot do GL_RED or GL_RG without GL_EXT_texture_rg.
+So, add check for GL_EXT_texture_rg to make it working. Also add
+a yuv2 pixman format into render.h to make Xv yuv rendering works.
+
+Signed-off-by: Yuriy Vasilev <uuvasiliev@yandex.ru>
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Reviewed-by: Emma Anholt <emma@anholt.net>
+---
+ glamor/glamor.c      | 19 +++++++++++++++----
+ glamor/glamor_priv.h |  1 +
+ render/picture.h     |  5 ++++-
+ 3 files changed, 20 insertions(+), 5 deletions(-)
+
+diff --git a/glamor/glamor.c b/glamor/glamor.c
+index 0a757db356..c6bb01d8e9 100644
+--- a/glamor/glamor.c
++++ b/glamor/glamor.c
+@@ -223,7 +223,7 @@ glamor_create_pixmap(ScreenPtr screen, int w, int h, int depth,
+ 
+     pixmap_priv = glamor_get_pixmap_private(pixmap);
+ 
+-    pixmap_priv->is_cbcr = (usage == GLAMOR_CREATE_FORMAT_CBCR);
++    pixmap_priv->is_cbcr = (GLAMOR_CREATE_FORMAT_CBCR & usage) == GLAMOR_CREATE_FORMAT_CBCR;
+ 
+     pitch = (((w * pixmap->drawable.bitsPerPixel + 7) / 8) + 3) & ~3;
+     screen->ModifyPixmapHeader(pixmap, w, h, 0, 0, pitch, NULL);
+@@ -550,9 +550,10 @@ glamor_setup_formats(ScreenPtr screen)
+     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
+ 
+     /* Prefer r8 textures since they're required by GLES3 and core,
+-     * only falling back to a8 if we can't do them.
++     * only falling back to a8 if we can't do them. We cannot do them
++     * on GLES2 due to lack of texture swizzle.
+      */
+-    if (glamor_priv->is_gles || epoxy_has_gl_extension("GL_ARB_texture_rg")) {
++    if (glamor_priv->has_rg && glamor_priv->has_texture_swizzle) {
+         glamor_add_format(screen, 1, PICT_a1,
+                           GL_R8, GL_RED, GL_UNSIGNED_BYTE, FALSE);
+         glamor_add_format(screen, 8, PICT_a8,
+@@ -606,8 +607,13 @@ glamor_setup_formats(ScreenPtr screen)
+     }
+ 
+     glamor_priv->cbcr_format.depth = 16;
+-    glamor_priv->cbcr_format.internalformat = GL_RG8;
++    if (glamor_priv->is_gles && glamor_priv->has_rg) {
++        glamor_priv->cbcr_format.internalformat = GL_RG;
++    } else {
++        glamor_priv->cbcr_format.internalformat = GL_RG8;
++    }
+     glamor_priv->cbcr_format.format = GL_RG;
++    glamor_priv->cbcr_format.render_format = PICT_yuv2;
+     glamor_priv->cbcr_format.type = GL_UNSIGNED_BYTE;
+     glamor_priv->cbcr_format.rendering_supported = TRUE;
+ }
+@@ -787,6 +793,11 @@ glamor_init(ScreenPtr screen, unsigned int flags)
+     glamor_priv->has_clear_texture =
+         epoxy_gl_version() >= 44 ||
+         epoxy_has_gl_extension("GL_ARB_clear_texture");
++    /* GL_EXT_texture_rg is part of GLES3 core */
++    glamor_priv->has_rg =
++        (glamor_priv->is_gles && epoxy_gl_version() >= 30) ||
++        epoxy_has_gl_extension("GL_EXT_texture_rg") ||
++        epoxy_has_gl_extension("GL_ARB_texture_rg");
+ 
+     glamor_priv->can_copyplane = (gl_version >= 30);
+ 
+diff --git a/glamor/glamor_priv.h b/glamor/glamor_priv.h
+index 028a6d3740..da20bc5aa6 100644
+--- a/glamor/glamor_priv.h
++++ b/glamor/glamor_priv.h
+@@ -216,6 +216,7 @@ typedef struct glamor_screen_private {
+     Bool has_dual_blend;
+     Bool has_clear_texture;
+     Bool has_texture_swizzle;
++    Bool has_rg;
+     Bool is_core_profile;
+     Bool can_copyplane;
+     Bool use_gpu_shader4;
+diff --git a/render/picture.h b/render/picture.h
+index 4499a0021c..c3a73d1d8d 100644
+--- a/render/picture.h
++++ b/render/picture.h
+@@ -125,7 +125,10 @@ typedef enum _PictFormatShort {
+ /* 1bpp formats */
+     PICT_a1 = PIXMAN_a1,
+ 
+-    PICT_g1 = PIXMAN_g1
++    PICT_g1 = PIXMAN_g1,
++
++/* YCbCr formats */
++    PICT_yuv2 = PIXMAN_yuy2
+ } PictFormatShort;
+ 
+ /*
+-- 
+GitLab
+
+
+From 05b8401eeb263e1395aa5ceeb8b5cdbeb0585db6 Mon Sep 17 00:00:00 2001
+From: Vasily Khoruzhick <anarsoul@gmail.com>
+Date: Fri, 27 May 2022 18:00:56 -0700
+Subject: [PATCH 5/6] glamor: use dual source blend on GL 2.1 with
+ ARB_ES2_compatibility
+
+ARB_blend_func_extended may be exposed even without GLSL 1.30.
+In order to use it we need GLES2 shaders that are available if
+ARB_ES2_compatibility is exposed.
+
+Signed-off-by: Vasily Khoruzhick <anarsoul@gmail.com>
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Reviewed-by: Emma Anholt <emma@anholt.net>
+---
+ glamor/glamor.c                  |  6 ++++--
+ glamor/glamor_composite_glyphs.c | 20 +++++++++++++++++++-
+ glamor/glamor_program.c          | 23 ++++++++++++++++-------
+ glamor/glamor_program.h          |  5 +++--
+ glamor/glamor_render.c           | 32 ++++++++++++++++++++++++++++----
+ 5 files changed, 70 insertions(+), 16 deletions(-)
+
+diff --git a/glamor/glamor.c b/glamor/glamor.c
+index c6bb01d8e9..f15b5a18a3 100644
+--- a/glamor/glamor.c
++++ b/glamor/glamor.c
+@@ -788,8 +788,10 @@ glamor_init(ScreenPtr screen, unsigned int flags)
+         epoxy_gl_version() >= 30 ||
+         epoxy_has_gl_extension("GL_NV_pack_subimage");
+     glamor_priv->has_dual_blend =
+-        glamor_glsl_has_ints(glamor_priv) &&
+-        epoxy_has_gl_extension("GL_ARB_blend_func_extended");
++        (epoxy_has_gl_extension("GL_ARB_blend_func_extended") &&
++        (glamor_glsl_has_ints(glamor_priv) ||
++        epoxy_has_gl_extension("GL_ARB_ES2_compatibility"))) ||
++        epoxy_has_gl_extension("GL_EXT_blend_func_extended");
+     glamor_priv->has_clear_texture =
+         epoxy_gl_version() >= 44 ||
+         epoxy_has_gl_extension("GL_ARB_clear_texture");
+diff --git a/glamor/glamor_composite_glyphs.c b/glamor/glamor_composite_glyphs.c
+index 147e3bb31a..c69b940d40 100644
+--- a/glamor/glamor_composite_glyphs.c
++++ b/glamor/glamor_composite_glyphs.c
+@@ -208,6 +208,22 @@ static const glamor_facet glamor_facet_composite_glyphs_120 = {
+     .locations = glamor_program_location_atlas,
+ };
+ 
++static const glamor_facet glamor_facet_composite_glyphs_gles2 = {
++    .name = "composite_glyphs",
++    .version = 100,
++    .fs_extensions = ("#extension GL_EXT_blend_func_extended : enable\n"),
++    .vs_vars = ("attribute vec2 primitive;\n"
++                "attribute vec2 source;\n"
++                "varying vec2 glyph_pos;\n"),
++    .vs_exec = ("       vec2 pos = vec2(0,0);\n"
++                GLAMOR_POS(gl_Position, primitive.xy)
++                "       glyph_pos = source.xy * ATLAS_DIM_INV;\n"),
++    .fs_vars = ("varying vec2 glyph_pos;\n"),
++    .fs_exec = ("       vec4 mask = texture2D(atlas, glyph_pos);\n"),
++    .source_name = "source",
++    .locations = glamor_program_location_atlas,
++};
++
+ static Bool
+ glamor_glyphs_init_facet(ScreenPtr screen)
+ {
+@@ -442,7 +458,9 @@ glamor_composite_glyphs(CARD8 op,
+                         else
+                             prog = glamor_setup_program_render(op, src, glyph_pict, dst,
+                                                                glyphs_program,
+-                                                               &glamor_facet_composite_glyphs_120,
++                                                               glamor_priv->has_dual_blend ?
++                                                                   &glamor_facet_composite_glyphs_gles2 :
++                                                                   &glamor_facet_composite_glyphs_120,
+                                                                glamor_priv->glyph_defines);
+                         if (!prog)
+                             goto bail_one;
+diff --git a/glamor/glamor_program.c b/glamor/glamor_program.c
+index d8ddb4c773..46a506aafe 100644
+--- a/glamor/glamor_program.c
++++ b/glamor/glamor_program.c
+@@ -201,6 +201,8 @@ static const char vs_template[] =
+ static const char fs_template[] =
+     "%s"                                /* version */
+     "%s"                                /* exts */
++    "%s"                                /* prim fs_extensions */
++    "%s"                                /* fill fs_extensions */
+     GLAMOR_DEFAULT_PRECISION
+     "%s"                                /* defines */
+     "%s"                                /* prim fs_vars */
+@@ -312,6 +314,8 @@ glamor_build_program(ScreenPtr          screen,
+     if (asprintf(&fs_prog_string,
+                  fs_template,
+                  str(version_string),
++                 str(prim->fs_extensions),
++                 str(fill->fs_extensions),
+                  gpu_shader4 ? "#extension GL_EXT_gpu_shader4 : require\n#define texelFetch texelFetch2D\n#define uint unsigned int\n" : "",
+                  str(defines),
+                  str(prim->fs_vars),
+@@ -494,7 +498,8 @@ glamor_set_blend(CARD8 op, glamor_program_alpha alpha, PicturePtr dst)
+     }
+ 
+     /* Set up the source alpha value for blending in component alpha mode. */
+-    if (alpha == glamor_program_alpha_dual_blend) {
++    if (alpha == glamor_program_alpha_dual_blend ||
++        alpha == glamor_program_alpha_dual_blend_gles2) {
+         switch (dst_blend) {
+         case GL_SRC_ALPHA:
+             dst_blend = GL_SRC1_COLOR;
+@@ -581,11 +586,13 @@ static const glamor_facet *glamor_facet_source[glamor_program_source_count] = {
+ };
+ 
+ static const char *glamor_combine[] = {
+-    [glamor_program_alpha_normal]    = "       gl_FragColor = source * mask.a;\n",
+-    [glamor_program_alpha_ca_first]  = "       gl_FragColor = source.a * mask;\n",
+-    [glamor_program_alpha_ca_second] = "       gl_FragColor = source * mask;\n",
+-    [glamor_program_alpha_dual_blend] = "      color0 = source * mask;\n"
+-                                        "      color1 = source.a * mask;\n"
++    [glamor_program_alpha_normal]    = "        gl_FragColor = source * mask.a;\n",
++    [glamor_program_alpha_ca_first]  = "        gl_FragColor = source.a * mask;\n",
++    [glamor_program_alpha_ca_second] = "        gl_FragColor = source * mask;\n",
++    [glamor_program_alpha_dual_blend] = "       color0 = source * mask;\n"
++                                        "       color1 = source.a * mask;\n",
++    [glamor_program_alpha_dual_blend_gles2] = " gl_FragColor = source * mask;\n"
++                                              " gl_SecondaryFragColorEXT = source.a * mask;\n"
+ };
+ 
+ static Bool
+@@ -633,7 +640,9 @@ glamor_setup_program_render(CARD8                 op,
+ 
+     if (glamor_is_component_alpha(mask)) {
+         if (glamor_priv->has_dual_blend) {
+-            alpha = glamor_program_alpha_dual_blend;
++            alpha = glamor_glsl_has_ints(glamor_priv) ?
++                    glamor_program_alpha_dual_blend :
++                    glamor_program_alpha_dual_blend_gles2;
+         } else {
+             /* This only works for PictOpOver */
+             if (op != PictOpOver)
+diff --git a/glamor/glamor_program.h b/glamor/glamor_program.h
+index ab6e46f7b5..0bd918fff3 100644
+--- a/glamor/glamor_program.h
++++ b/glamor/glamor_program.h
+@@ -44,6 +44,7 @@ typedef enum {
+     glamor_program_alpha_ca_first,
+     glamor_program_alpha_ca_second,
+     glamor_program_alpha_dual_blend,
++    glamor_program_alpha_dual_blend_gles2,
+     glamor_program_alpha_count
+ } glamor_program_alpha;
+ 
+@@ -56,8 +57,8 @@ typedef Bool (*glamor_use_render) (CARD8 op, PicturePtr src, PicturePtr dst, gla
+ typedef struct {
+     const char                          *name;
+     const int                           version;
+-    char                                *vs_defines;
+-    char                                *fs_defines;
++    char                                *vs_extensions;
++    const char                          *fs_extensions;
+     const char                          *vs_vars;
+     const char                          *vs_exec;
+     const char                          *fs_vars;
+diff --git a/glamor/glamor_render.c b/glamor/glamor_render.c
+index 2af65bf936..c9a125ef9d 100644
+--- a/glamor/glamor_render.c
++++ b/glamor/glamor_render.c
+@@ -223,6 +223,15 @@ glamor_create_composite_fs(struct shader_key *key)
+         "}\n";
+     const char *header_ca_dual_blend =
+         "#version 130\n";
++    const char *in_ca_dual_blend_gles2 =
++        "void main()\n"
++        "{\n"
++        "	gl_FragColor = dest_swizzle(get_source() * get_mask());\n"
++        "	gl_SecondaryFragColorEXT = dest_swizzle(get_source().a * get_mask());\n"
++        "}\n";
++    const char *header_ca_dual_blend_gles2 =
++        "#version 100\n"
++        "#extension GL_EXT_blend_func_extended : require\n";
+ 
+     char *source;
+     const char *source_fetch;
+@@ -294,6 +303,10 @@ glamor_create_composite_fs(struct shader_key *key)
+         in = in_ca_dual_blend;
+         header = header_ca_dual_blend;
+         break;
++    case glamor_program_alpha_dual_blend_gles2:
++        in = in_ca_dual_blend_gles2;
++        header = header_ca_dual_blend_gles2;
++        break;
+     default:
+         FatalError("Bad composite IN type");
+     }
+@@ -327,6 +340,8 @@ glamor_create_composite_vs(struct shader_key *key)
+     const char *main_closing = "}\n";
+     const char *source_coords_setup = "";
+     const char *mask_coords_setup = "";
++    const char *version_gles2 = "#version 100\n";
++    const char *version = "";
+     char *source;
+     GLuint prog;
+ 
+@@ -336,10 +351,15 @@ glamor_create_composite_vs(struct shader_key *key)
+     if (key->mask != SHADER_MASK_NONE && key->mask != SHADER_MASK_SOLID)
+         mask_coords_setup = mask_coords;
+ 
++    if (key->in == glamor_program_alpha_dual_blend_gles2)
++        version = version_gles2;
++
+     XNFasprintf(&source,
++                "%s"
++                GLAMOR_DEFAULT_PRECISION
+                 "%s%s%s%s",
+-                main_opening,
+-                source_coords_setup, mask_coords_setup, main_closing);
++                version, main_opening, source_coords_setup,
++                mask_coords_setup, main_closing);
+ 
+     prog = glamor_compile_glsl_prog(GL_VERTEX_SHADER, source);
+     free(source);
+@@ -701,6 +721,7 @@ combine_pict_format(PictFormatShort * des, const PictFormatShort src,
+         mask_type = PICT_FORMAT_TYPE(mask);
+         break;
+     case glamor_program_alpha_dual_blend:
++    case glamor_program_alpha_dual_blend_gles2:
+         src_type = PICT_FORMAT_TYPE(src);
+         mask_type = PICT_FORMAT_TYPE(mask);
+         break;
+@@ -886,8 +907,11 @@ glamor_composite_choose_shader(CARD8 op,
+         else {
+             if (op == PictOpClear)
+                 key.mask = SHADER_MASK_NONE;
+-            else if (glamor_priv->has_dual_blend)
+-                key.in = glamor_program_alpha_dual_blend;
++            else if (glamor_priv->has_dual_blend) {
++                key.in = glamor_glsl_has_ints(glamor_priv) ?
++                    glamor_program_alpha_dual_blend :
++                    glamor_program_alpha_dual_blend_gles2;
++            }
+             else if (op == PictOpSrc || op == PictOpAdd
+                      || op == PictOpIn || op == PictOpOut
+                      || op == PictOpOverReverse)
+-- 
+GitLab
+
+
+From dcba460af3eedb9d41986bd65f4502998b7a5a6c Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Tue, 28 Jun 2022 12:28:39 +0300
+Subject: [PATCH 6/6] glamor: fix XVideo run with GLES
+
+For now, it sets .version=120, which prevents shader from compiling on ES.
+We just force version of shaders to be always 100 on ES, because we use
+only 120 shaders on ES anyway, and all shaders works.
+
+Signed-off-by: Konstantin Pugin <ria.freelander@gmail.com>
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Reviewed-by: Emma Anholt <emma@anholt.net>
+---
+ glamor/glamor_program.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/glamor/glamor_program.c b/glamor/glamor_program.c
+index 46a506aafe..f361b726e2 100644
+--- a/glamor/glamor_program.c
++++ b/glamor/glamor_program.c
+@@ -283,6 +283,11 @@ glamor_build_program(ScreenPtr          screen,
+             gpu_shader4 = TRUE;
+         }
+     }
++    /* For now, fix shader version to GLES as 100. We will fall with 130 shaders
++     * in previous check due to forcibly set 120 glsl for GLES. But this patch
++     * makes xv shaders to work */
++    if(version && glamor_priv->is_gles)
++        version = 100;
+ 
+     vs_vars = vs_location_vars(locations);
+     fs_vars = fs_location_vars(locations);
+-- 
+GitLab
+

--- a/debian/patches/glamor-gles/1001-glamor-add-gl_PointSize-for-ES-shaders.patch
+++ b/debian/patches/glamor-gles/1001-glamor-add-gl_PointSize-for-ES-shaders.patch
@@ -1,0 +1,72 @@
+From f273c960c15cf1eaaaccf9c00ed93f5ac75c9397 Mon Sep 17 00:00:00 2001
+From: Konstantin <ria.freelander@gmail.com>
+Date: Tue, 19 Jul 2022 11:22:30 +0300
+Subject: [PATCH] glamor: add gl_PointSize for ES shaders
+
+GLES3.2 spec, page 126:
+> The variable gl_PointSize is intended for a shader to write
+> the size of the point to be rasterized. It is measured in pixels.
+> If gl_PointSize is not written to, its value
+> is undefined in subsequent pipe stages.
+
+If glamor shader is use points, we should define gl_PointSize for GLES.
+On Desktop GL, it "just work" due to default gl_PointSize is 1.
+
+As @anholt requested, define this only for minimal amount of shaders
+(point and glyphbit ones), to make sure than performance will not
+affected
+
+Reviewed-by: Emma Anholt <emma@anholt.net>
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+Signed-off-by: Konstantin <ria.freelander@gmail.com>
+---
+ glamor/glamor_glyphblt.c | 1 +
+ glamor/glamor_points.c   | 3 ++-
+ glamor/glamor_priv.h     | 5 +++++
+ 3 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/glamor/glamor_glyphblt.c b/glamor/glamor_glyphblt.c
+index 808e9066be..ddc02656de 100644
+--- a/glamor/glamor_glyphblt.c
++++ b/glamor/glamor_glyphblt.c
+@@ -34,6 +34,7 @@ static const glamor_facet glamor_facet_poly_glyph_blt = {
+     .name = "poly_glyph_blt",
+     .vs_vars = "attribute vec2 primitive;\n",
+     .vs_exec = ("       vec2 pos = vec2(0,0);\n"
++                GLAMOR_DEFAULT_POINT_SIZE
+                 GLAMOR_POS(gl_Position, primitive)),
+ };
+ 
+diff --git a/glamor/glamor_points.c b/glamor/glamor_points.c
+index 8f0e4b1da3..d6d6784f70 100644
+--- a/glamor/glamor_points.c
++++ b/glamor/glamor_points.c
+@@ -32,7 +32,8 @@
+ static const glamor_facet glamor_facet_point = {
+     .name = "poly_point",
+     .vs_vars = "attribute vec2 primitive;\n",
+-    .vs_exec = GLAMOR_POS(gl_Position, primitive),
++    .vs_exec = (GLAMOR_DEFAULT_POINT_SIZE
++                GLAMOR_POS(gl_Position, primitive)),
+ };
+ 
+ static Bool
+diff --git a/glamor/glamor_priv.h b/glamor/glamor_priv.h
+index 71aaeb8c24..ea27abdd5c 100644
+--- a/glamor/glamor_priv.h
++++ b/glamor/glamor_priv.h
+@@ -49,6 +49,11 @@
+     "precision mediump float;\n"  \
+     "#endif\n"
+ 
++#define GLAMOR_DEFAULT_POINT_SIZE  \
++    "#ifdef GL_ES\n"              \
++    "       gl_PointSize = 1.0;\n"  \
++    "#endif\n"
++
+ #include "glyphstr.h"
+ 
+ #include "glamor_debug.h"
+-- 
+GitLab
+

--- a/debian/patches/glamor-gles/1002-glamor-handle-EXT_gpu_shader4-in-dual-source-blend-paths.patch
+++ b/debian/patches/glamor-gles/1002-glamor-handle-EXT_gpu_shader4-in-dual-source-blend-paths.patch
@@ -1,0 +1,57 @@
+From 86598739ba285045bc03778d43e25bb0886627f3 Mon Sep 17 00:00:00 2001
+From: Dave Airlie <airlied@redhat.com>
+Date: Thu, 9 Feb 2023 13:48:30 +1000
+Subject: [PATCH] glamor: handle EXT_gpu_shader4 in dual source blend paths
+
+Fixes: a9552868697c ("glamor: add EXT_gpu_shader4 support")
+Acked-by: Emma Anholt <emma@anholt.net>
+---
+ glamor/glamor_render.c | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/glamor/glamor_render.c b/glamor/glamor_render.c
+index c9a125ef9d..889fe1b369 100644
+--- a/glamor/glamor_render.c
++++ b/glamor/glamor_render.c
+@@ -61,7 +61,7 @@ static struct blendinfo composite_op_info[] = {
+ 
+ #define RepeatFix			10
+ static GLuint
+-glamor_create_composite_fs(struct shader_key *key)
++glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key *key)
+ {
+     const char *repeat_define =
+         "#define RepeatNone               	      0\n"
+@@ -223,6 +223,8 @@ glamor_create_composite_fs(struct shader_key *key)
+         "}\n";
+     const char *header_ca_dual_blend =
+         "#version 130\n";
++    const char *header_ca_dual_blend_gpu_shader4 =
++        "#version 120\n#extension GL_EXT_gpu_shader4 : require\n";
+     const char *in_ca_dual_blend_gles2 =
+         "void main()\n"
+         "{\n"
+@@ -301,7 +303,10 @@ glamor_create_composite_fs(struct shader_key *key)
+         break;
+     case glamor_program_alpha_dual_blend:
+         in = in_ca_dual_blend;
+-        header = header_ca_dual_blend;
++        if (glamor_priv->glsl_version >= 130)
++           header = header_ca_dual_blend;
++        else
++           header = header_ca_dual_blend_gpu_shader4;
+         break;
+     case glamor_program_alpha_dual_blend_gles2:
+         in = in_ca_dual_blend_gles2;
+@@ -379,7 +384,7 @@ glamor_create_composite_shader(ScreenPtr screen, struct shader_key *key,
+     vs = glamor_create_composite_vs(key);
+     if (vs == 0)
+         return;
+-    fs = glamor_create_composite_fs(key);
++    fs = glamor_create_composite_fs(glamor_priv, key);
+     if (fs == 0)
+         return;
+ 
+-- 
+GitLab
+

--- a/debian/patches/glamor-gles/1003-glamor-supports-GLES3-shaders.patch
+++ b/debian/patches/glamor-gles/1003-glamor-supports-GLES3-shaders.patch
@@ -1,0 +1,768 @@
+From ee107cd4911e692480ab2ff9c12e3c6958bdec4e Mon Sep 17 00:00:00 2001
+From: Konstantin Pugin <ria.freelander@gmail.com>
+Date: Sun, 24 Jul 2022 16:03:51 +0300
+Subject: [PATCH] glamor: support GLES3 shaders
+
+Some hardware (preferably mobile) working on GLES3 way faster than
+on desktop GL and supports more features. This commit will allow using
+GLES3 if glamor is running over GL ES, and version 3 is supported.
+
+Changes are the following:
+1. Add compatibility layer for 120/GLES2 shaders with defines in and out
+2. Switch attribute and varying to in and out in almost all shaders
+   (aside gradient)
+3. Add newGL-only frag_color variable, which defines as gl_FragColor on
+   old pipelines
+4. Switch all shaders to use frag_color.
+5. Previous commit is reverted, because now we have more than one GL ES
+version, previous commit used to set version 100 for all ES shaders, which
+is not true for ES 3
+
+Signed-off-by: Konstantin Pugin <ria.freelander@gmail.com>
+---
+ glamor/glamor.c                  | 12 +-----
+ glamor/glamor_composite_glyphs.c | 10 ++---
+ glamor/glamor_copy.c             | 12 +++---
+ glamor/glamor_dash.c             | 14 +++----
+ glamor/glamor_glyphblt.c         |  2 +-
+ glamor/glamor_lines.c            |  2 +-
+ glamor/glamor_points.c           |  2 +-
+ glamor/glamor_priv.h             | 13 +++++++
+ glamor/glamor_program.c          | 54 ++++++++++++++++-----------
+ glamor/glamor_rects.c            |  4 +-
+ glamor/glamor_render.c           | 64 ++++++++++++++++----------------
+ glamor/glamor_segs.c             |  2 +-
+ glamor/glamor_spans.c            |  2 +-
+ glamor/glamor_text.c             | 14 +++----
+ glamor/glamor_xv.c               | 30 +++++++--------
+ 15 files changed, 125 insertions(+), 112 deletions(-)
+
+diff --git a/glamor/glamor.c b/glamor/glamor.c
+index 848b484cf9..a2cee41a03 100644
+--- a/glamor/glamor.c
++++ b/glamor/glamor.c
+@@ -689,17 +689,6 @@ glamor_init(ScreenPtr screen, unsigned int flags)
+ 
+     glamor_priv->glsl_version = epoxy_glsl_version();
+ 
+-    if (glamor_priv->is_gles) {
+-        /* Force us back to the base version of our programs on an ES
+-         * context, anyway.  Basically glamor only uses desktop 1.20
+-         * or 1.30 currently.  1.30's new features are also present in
+-         * ES 3.0, but our glamor_program.c constructions use a lot of
+-         * compatibility features (to reduce the diff between 1.20 and
+-         * 1.30 programs).
+-         */
+-        glamor_priv->glsl_version = 120;
+-    }
+-
+     /* We'd like to require GL_ARB_map_buffer_range or
+      * GL_OES_map_buffer_range, since it offers more information to
+      * the driver than plain old glMapBuffer() or glBufferSubData().
+@@ -733,6 +722,7 @@ glamor_init(ScreenPtr screen, unsigned int flags)
+          * etnaviv offers GLSL 140 with OpenGL 2.1.
+          */
+         if (glamor_glsl_has_ints(glamor_priv) &&
++            !glamor_priv->is_gles &&
+             !epoxy_has_gl_extension("GL_ARB_instanced_arrays"))
+                 glamor_priv->glsl_version = 120;
+     } else {
+diff --git a/glamor/glamor_composite_glyphs.c b/glamor/glamor_composite_glyphs.c
+index 7911e0009f..f208504dd1 100644
+--- a/glamor/glamor_composite_glyphs.c
++++ b/glamor/glamor_composite_glyphs.c
+@@ -180,16 +180,16 @@ glamor_glyph_add(struct glamor_glyph_atlas *atlas, DrawablePtr glyph_draw)
+ static const glamor_facet glamor_facet_composite_glyphs_130 = {
+     .name = "composite_glyphs",
+     .version = 130,
+-    .vs_vars = ("attribute vec4 primitive;\n"
+-                "attribute vec2 source;\n"
+-                "varying vec2 glyph_pos;\n"),
++    .vs_vars = ("in vec4 primitive;\n"
++                "in vec2 source;\n"
++                "out vec2 glyph_pos;\n"),
+     .vs_exec = ("       vec2 pos = primitive.zw * vec2(gl_VertexID&1, (gl_VertexID&2)>>1);\n"
+                 GLAMOR_POS(gl_Position, (primitive.xy + pos))
+                 "       glyph_pos = (source + pos) * ATLAS_DIM_INV;\n"),
+-    .fs_vars = ("varying vec2 glyph_pos;\n"
++    .fs_vars = ("in vec2 glyph_pos;\n"
+                 "out vec4 color0;\n"
+                 "out vec4 color1;\n"),
+-    .fs_exec = ("       vec4 mask = texture2D(atlas, glyph_pos);\n"),
++    .fs_exec = ("       vec4 mask = texture(atlas, glyph_pos);\n"),
+     .source_name = "source",
+     .locations = glamor_program_location_atlas,
+ };
+diff --git a/glamor/glamor_copy.c b/glamor/glamor_copy.c
+index 08b55b67bb..00a04d94f8 100644
+--- a/glamor/glamor_copy.c
++++ b/glamor/glamor_copy.c
+@@ -49,10 +49,10 @@ use_copyarea(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ 
+ static const glamor_facet glamor_facet_copyarea = {
+     "copy_area",
+-    .vs_vars = "attribute vec2 primitive;\n",
++    .vs_vars = "in vec2 primitive;\n",
+     .vs_exec = (GLAMOR_POS(gl_Position, primitive.xy)
+                 "       fill_pos = (fill_offset + primitive.xy) * fill_size_inv;\n"),
+-    .fs_exec = "       gl_FragColor = texture2D(sampler, fill_pos);\n",
++    .fs_exec = "       frag_color = texture(sampler, fill_pos);\n",
+     .locations = glamor_program_location_fillsamp | glamor_program_location_fillpos,
+     .use = use_copyarea,
+ };
+@@ -141,14 +141,14 @@ use_copyplane(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ static const glamor_facet glamor_facet_copyplane = {
+     "copy_plane",
+     .version = 130,
+-    .vs_vars = "attribute vec2 primitive;\n",
++    .vs_vars = "in vec2 primitive;\n",
+     .vs_exec = (GLAMOR_POS(gl_Position, (primitive.xy))
+                 "       fill_pos = (fill_offset + primitive.xy) * fill_size_inv;\n"),
+-    .fs_exec = ("       uvec4 bits = uvec4(round(texture2D(sampler, fill_pos) * bitmul));\n"
++    .fs_exec = ("       uvec4 bits = uvec4(round(texture(sampler, fill_pos) * bitmul));\n"
+                 "       if ((bits & bitplane) != uvec4(0,0,0,0))\n"
+-                "               gl_FragColor = fg;\n"
++                "               frag_color = fg;\n"
+                 "       else\n"
+-                "               gl_FragColor = bg;\n"),
++                "               frag_color = bg;\n"),
+     .locations = glamor_program_location_fillsamp|glamor_program_location_fillpos|glamor_program_location_fg|glamor_program_location_bg|glamor_program_location_bitplane,
+     .use = use_copyplane,
+ };
+diff --git a/glamor/glamor_dash.c b/glamor/glamor_dash.c
+index e0fe0e7e03..828969d915 100644
+--- a/glamor/glamor_dash.c
++++ b/glamor/glamor_dash.c
+@@ -27,8 +27,8 @@
+ #include "glamor_prepare.h"
+ 
+ static const char dash_vs_vars[] =
+-    "attribute vec3 primitive;\n"
+-    "varying float dash_offset;\n";
++    "in vec3 primitive;\n"
++    "out float dash_offset;\n";
+ 
+ static const char dash_vs_exec[] =
+     "       dash_offset = primitive.z / dash_length;\n"
+@@ -36,20 +36,20 @@ static const char dash_vs_exec[] =
+     GLAMOR_POS(gl_Position, primitive.xy);
+ 
+ static const char dash_fs_vars[] =
+-    "varying float dash_offset;\n";
++    "in float dash_offset;\n";
+ 
+ static const char on_off_fs_exec[] =
+-    "       float pattern = texture2D(dash, vec2(dash_offset, 0.5)).w;\n"
++    "       float pattern = texture(dash, vec2(dash_offset, 0.5)).w;\n"
+     "       if (pattern == 0.0)\n"
+     "               discard;\n";
+ 
+ /* XXX deal with stippled double dashed lines once we have stippling support */
+ static const char double_fs_exec[] =
+-    "       float pattern = texture2D(dash, vec2(dash_offset, 0.5)).w;\n"
++    "       float pattern = texture(dash, vec2(dash_offset, 0.5)).w;\n"
+     "       if (pattern == 0.0)\n"
+-    "               gl_FragColor = bg;\n"
++    "               frag_color = bg;\n"
+     "       else\n"
+-    "               gl_FragColor = fg;\n";
++    "               frag_color = fg;\n";
+ 
+ 
+ static const glamor_facet glamor_facet_on_off_dash_lines = {
+diff --git a/glamor/glamor_glyphblt.c b/glamor/glamor_glyphblt.c
+index ddc02656de..44f6688185 100644
+--- a/glamor/glamor_glyphblt.c
++++ b/glamor/glamor_glyphblt.c
+@@ -32,7 +32,7 @@
+ 
+ static const glamor_facet glamor_facet_poly_glyph_blt = {
+     .name = "poly_glyph_blt",
+-    .vs_vars = "attribute vec2 primitive;\n",
++    .vs_vars = "in vec2 primitive;\n",
+     .vs_exec = ("       vec2 pos = vec2(0,0);\n"
+                 GLAMOR_DEFAULT_POINT_SIZE
+                 GLAMOR_POS(gl_Position, primitive)),
+diff --git a/glamor/glamor_lines.c b/glamor/glamor_lines.c
+index ec70804acf..c9b776bb57 100644
+--- a/glamor/glamor_lines.c
++++ b/glamor/glamor_lines.c
+@@ -27,7 +27,7 @@
+ 
+ static const glamor_facet glamor_facet_poly_lines = {
+     .name = "poly_lines",
+-    .vs_vars = "attribute vec2 primitive;\n",
++    .vs_vars = "in vec2 primitive;\n",
+     .vs_exec = ("       vec2 pos = vec2(0.0,0.0);\n"
+                 GLAMOR_POS(gl_Position, primitive.xy)),
+ };
+diff --git a/glamor/glamor_points.c b/glamor/glamor_points.c
+index d6d6784f70..91b5e4789a 100644
+--- a/glamor/glamor_points.c
++++ b/glamor/glamor_points.c
+@@ -31,7 +31,7 @@
+ 
+ static const glamor_facet glamor_facet_point = {
+     .name = "poly_point",
+-    .vs_vars = "attribute vec2 primitive;\n",
++    .vs_vars = "in vec2 primitive;\n",
+     .vs_exec = (GLAMOR_DEFAULT_POINT_SIZE
+                 GLAMOR_POS(gl_Position, primitive)),
+ };
+diff --git a/glamor/glamor_priv.h b/glamor/glamor_priv.h
+index ea27abdd5c..d8da1a0c12 100644
+--- a/glamor/glamor_priv.h
++++ b/glamor/glamor_priv.h
+@@ -54,6 +54,19 @@
+     "       gl_PointSize = 1.0;\n"  \
+     "#endif\n"
+ 
++#define GLAMOR_COMPAT_DEFINES_VS  \
++    "#define in attribute\n" \
++    "#define out varying\n"  \
++
++#define GLAMOR_COMPAT_DEFINES_FS  \
++    "#if __VERSION__ < 130\n" \
++    "#define in varying\n"  \
++    "#define frag_color gl_FragColor\n" \
++    "#define texture texture2D\n" \
++    "#else\n" \
++    "out vec4 frag_color;\n" \
++    "#endif\n"
++
+ #include "glyphstr.h"
+ 
+ #include "glamor_debug.h"
+diff --git a/glamor/glamor_program.c b/glamor/glamor_program.c
+index 9ee945d11c..6f08e3211e 100644
+--- a/glamor/glamor_program.c
++++ b/glamor/glamor_program.c
+@@ -32,7 +32,7 @@ use_solid(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ 
+ const glamor_facet glamor_fill_solid = {
+     .name = "solid",
+-    .fs_exec = "       gl_FragColor = fg;\n",
++    .fs_exec = "       frag_color = fg;\n",
+     .locations = glamor_program_location_fg,
+     .use = use_solid,
+ };
+@@ -46,7 +46,7 @@ use_tile(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ static const glamor_facet glamor_fill_tile = {
+     .name = "tile",
+     .vs_exec =  "       fill_pos = (fill_offset + primitive.xy + pos) * fill_size_inv;\n",
+-    .fs_exec =  "       gl_FragColor = texture2D(sampler, fill_pos);\n",
++    .fs_exec =  "       frag_color = texture(sampler, fill_pos);\n",
+     .locations = glamor_program_location_fillsamp | glamor_program_location_fillpos,
+     .use = use_tile,
+ };
+@@ -62,10 +62,10 @@ use_stipple(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ static const glamor_facet glamor_fill_stipple = {
+     .name = "stipple",
+     .vs_exec =  "       fill_pos = (fill_offset + primitive.xy + pos) * fill_size_inv;\n",
+-    .fs_exec = ("       float a = texture2D(sampler, fill_pos).w;\n"
++    .fs_exec = ("       float a = texture(sampler, fill_pos).w;\n"
+                 "       if (a == 0.0)\n"
+                 "               discard;\n"
+-                "       gl_FragColor = fg;\n"),
++                "       frag_color = fg;\n"),
+     .locations = glamor_program_location_fg | glamor_program_location_fillsamp | glamor_program_location_fillpos,
+     .use = use_stipple,
+ };
+@@ -82,11 +82,11 @@ use_opaque_stipple(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *a
+ static const glamor_facet glamor_fill_opaque_stipple = {
+     .name = "opaque_stipple",
+     .vs_exec =  "       fill_pos = (fill_offset + primitive.xy + pos) * fill_size_inv;\n",
+-    .fs_exec = ("       float a = texture2D(sampler, fill_pos).w;\n"
++    .fs_exec = ("       float a = texture(sampler, fill_pos).w;\n"
+                 "       if (a == 0.0)\n"
+-                "               gl_FragColor = bg;\n"
++                "               frag_color = bg;\n"
+                 "       else\n"
+-                "               gl_FragColor = fg;\n"),
++                "               frag_color = fg;\n"),
+     .locations = glamor_program_location_fg | glamor_program_location_bg | glamor_program_location_fillsamp | glamor_program_location_fillpos,
+     .use = use_opaque_stipple
+ };
+@@ -121,12 +121,15 @@ static glamor_location_var location_vars[] = {
+         .location = glamor_program_location_fillpos,
+         .vs_vars = ("uniform vec2 fill_offset;\n"
+                     "uniform vec2 fill_size_inv;\n"
+-                    "varying vec2 fill_pos;\n"),
+-        .fs_vars = ("varying vec2 fill_pos;\n")
++                    "out vec2 fill_pos;\n"),
++        .fs_vars = ("in vec2 fill_pos;\n")
+     },
+     {
+         .location = glamor_program_location_font,
+-        .fs_vars = "uniform usampler2D font;\n",
++        .fs_vars = ("#ifdef GL_ES\n"
++                    "precision mediump usampler2D;\n"
++                    "#endif\n"
++                    "uniform usampler2D font;\n"),
+     },
+     {
+         .location = glamor_program_location_bitplane,
+@@ -188,6 +191,7 @@ fs_location_vars(glamor_program_location locations)
+ static const char vs_template[] =
+     "%s"                                /* version */
+     "%s"                                /* exts */
++    "%s"                                /* in/out defines */
+     "%s"                                /* defines */
+     "%s"                                /* prim vs_vars */
+     "%s"                                /* fill vs_vars */
+@@ -204,6 +208,7 @@ static const char fs_template[] =
+     "%s"                                /* prim fs_extensions */
+     "%s"                                /* fill fs_extensions */
+     GLAMOR_DEFAULT_PRECISION
++    "%s"                                /* in/out defines */
+     "%s"                                /* defines */
+     "%s"                                /* prim fs_vars */
+     "%s"                                /* fill fs_vars */
+@@ -283,11 +288,13 @@ glamor_build_program(ScreenPtr          screen,
+             gpu_shader4 = TRUE;
+         }
+     }
+-    /* For now, fix shader version to GLES as 100. We will fall with 130 shaders
+-     * in previous check due to forcibly set 120 glsl for GLES. But this patch
+-     * makes xv shaders to work */
+-    if(version && glamor_priv->is_gles)
++
++    if (version == 130 && glamor_priv->is_gles && glamor_priv->glsl_version > 110)
++        version = 300;
++    else if (glamor_priv->is_gles)
+         version = 100;
++    else if (!version)
++        version = 120;
+ 
+     vs_vars = vs_location_vars(locations);
+     fs_vars = fs_location_vars(locations);
+@@ -298,7 +305,8 @@ glamor_build_program(ScreenPtr          screen,
+         goto fail;
+ 
+     if (version) {
+-        if (asprintf(&version_string, "#version %d\n", version) < 0)
++        if (asprintf(&version_string, "#version %d %s\n", version,
++                     glamor_priv->is_gles && version > 100 ? "es" : "") < 0)
+             version_string = NULL;
+         if (!version_string)
+             goto fail;
+@@ -308,6 +316,7 @@ glamor_build_program(ScreenPtr          screen,
+                  vs_template,
+                  str(version_string),
+                  gpu_shader4 ? "#extension GL_EXT_gpu_shader4 : require\n" : "",
++                 version < 130 ? GLAMOR_COMPAT_DEFINES_VS : "",
+                  str(defines),
+                  str(prim->vs_vars),
+                  str(fill->vs_vars),
+@@ -322,6 +331,7 @@ glamor_build_program(ScreenPtr          screen,
+                  str(prim->fs_extensions),
+                  str(fill->fs_extensions),
+                  gpu_shader4 ? "#extension GL_EXT_gpu_shader4 : require\n#define texelFetch texelFetch2D\n#define uint unsigned int\n" : "",
++                 GLAMOR_COMPAT_DEFINES_FS,
+                  str(defines),
+                  str(prim->fs_vars),
+                  str(fill->fs_vars),
+@@ -563,7 +573,7 @@ use_source_picture(CARD8 op, PicturePtr src, PicturePtr dst, glamor_program *pro
+ static const glamor_facet glamor_source_picture = {
+     .name = "render_picture",
+     .vs_exec =  "       fill_pos = (fill_offset + primitive.xy + pos) * fill_size_inv;\n",
+-    .fs_exec =  "       vec4 source = texture2D(sampler, fill_pos);\n",
++    .fs_exec =  "       vec4 source = texture(sampler, fill_pos);\n",
+     .locations = glamor_program_location_fillsamp | glamor_program_location_fillpos,
+     .use_render = use_source_picture,
+ };
+@@ -579,7 +589,7 @@ use_source_1x1_picture(CARD8 op, PicturePtr src, PicturePtr dst, glamor_program
+ 
+ static const glamor_facet glamor_source_1x1_picture = {
+     .name = "render_picture",
+-    .fs_exec =  "       vec4 source = texture2D(sampler, vec2(0.5));\n",
++    .fs_exec =  "       vec4 source = texture(sampler, vec2(0.5));\n",
+     .locations = glamor_program_location_fillsamp,
+     .use_render = use_source_1x1_picture,
+ };
+@@ -591,11 +601,11 @@ static const glamor_facet *glamor_facet_source[glamor_program_source_count] = {
+ };
+ 
+ static const char *glamor_combine[] = {
+-    [glamor_program_alpha_normal]    = "        gl_FragColor = source * mask.a;\n",
+-    [glamor_program_alpha_ca_first]  = "        gl_FragColor = source.a * mask;\n",
+-    [glamor_program_alpha_ca_second] = "        gl_FragColor = source * mask;\n",
+-    [glamor_program_alpha_dual_blend] = "       color0 = source * mask;\n"
+-                                        "       color1 = source.a * mask;\n",
++    [glamor_program_alpha_normal]    = "       frag_color = source * mask.a;\n",
++    [glamor_program_alpha_ca_first]  = "       frag_color = source.a * mask;\n",
++    [glamor_program_alpha_ca_second] = "       frag_color = source * mask;\n",
++    [glamor_program_alpha_dual_blend] = "      color0 = source * mask;\n"
++                                        "      color1 = source.a * mask;\n",
+     [glamor_program_alpha_dual_blend_gles2] = " gl_FragColor = source * mask;\n"
+                                               " gl_SecondaryFragColorEXT = source.a * mask;\n"
+ };
+diff --git a/glamor/glamor_rects.c b/glamor/glamor_rects.c
+index afe680d1ba..aa05b8ceff 100644
+--- a/glamor/glamor_rects.c
++++ b/glamor/glamor_rects.c
+@@ -28,8 +28,8 @@ static const glamor_facet glamor_facet_polyfillrect_130 = {
+     .name = "poly_fill_rect",
+     .version = 130,
+     .source_name = "size",
+-    .vs_vars = "attribute vec2 primitive;\n"
+-               "attribute vec2 size;\n",
++    .vs_vars = "in vec2 primitive;\n"
++               "in vec2 size;\n",
+     .vs_exec = ("       vec2 pos = size * vec2(gl_VertexID&1, (gl_VertexID&2)>>1);\n"
+                 GLAMOR_POS(gl_Position, (primitive.xy + pos))),
+ };
+diff --git a/glamor/glamor_render.c b/glamor/glamor_render.c
+index 0d233f27b1..99c31fc2c5 100644
+--- a/glamor/glamor_render.c
++++ b/glamor/glamor_render.c
+@@ -116,7 +116,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         "			tex = (fract(tex) / wh.xy);\n"
+         "		}\n"
+         "	}\n"
+-        "	return texture2D(tex_image, tex);\n"
++        "	return texture(tex_image, tex);\n"
+         "}\n"
+         " vec4 rel_sampler_rgbx(sampler2D tex_image, vec2 tex, vec4 wh, int repeat)\n"
+         "{\n"
+@@ -129,7 +129,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         "			tex = (fract(tex) / wh.xy);\n"
+         "		}\n"
+         "	}\n"
+-        "	return vec4(texture2D(tex_image, tex).rgb, 1.0);\n"
++        "	return vec4(texture(tex_image, tex).rgb, 1.0);\n"
+         "}\n";
+ 
+     const char *source_solid_fetch =
+@@ -139,7 +139,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         "	return source;\n"
+         "}\n";
+     const char *source_alpha_pixmap_fetch =
+-        "varying vec2 source_texture;\n"
++        "in vec2 source_texture;\n"
+         "uniform sampler2D source_sampler;\n"
+         "uniform vec4 source_wh;"
+         "vec4 get_source()\n"
+@@ -148,7 +148,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         "			        source_wh, source_repeat_mode);\n"
+         "}\n";
+     const char *source_pixmap_fetch =
+-        "varying vec2 source_texture;\n"
++        "in vec2 source_texture;\n"
+         "uniform sampler2D source_sampler;\n"
+         "uniform vec4 source_wh;\n"
+         "vec4 get_source()\n"
+@@ -168,7 +168,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         "	return mask;\n"
+         "}\n";
+     const char *mask_alpha_pixmap_fetch =
+-        "varying vec2 mask_texture;\n"
++        "in vec2 mask_texture;\n"
+         "uniform sampler2D mask_sampler;\n"
+         "uniform vec4 mask_wh;\n"
+         "vec4 get_mask()\n"
+@@ -177,7 +177,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         "			        mask_wh, mask_repeat_mode);\n"
+         "}\n";
+     const char *mask_pixmap_fetch =
+-        "varying vec2 mask_texture;\n"
++        "in vec2 mask_texture;\n"
+         "uniform sampler2D mask_sampler;\n"
+         "uniform vec4 mask_wh;\n"
+         "vec4 get_mask()\n"
+@@ -206,17 +206,17 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+     const char *in_normal =
+         "void main()\n"
+         "{\n"
+-        "	gl_FragColor = dest_swizzle(get_source() * get_mask().a);\n"
++        "	frag_color = dest_swizzle(get_source() * get_mask().a);\n"
+         "}\n";
+     const char *in_ca_source =
+         "void main()\n"
+         "{\n"
+-        "	gl_FragColor = dest_swizzle(get_source() * get_mask());\n"
++        "	frag_color = dest_swizzle(get_source() * get_mask());\n"
+         "}\n";
+     const char *in_ca_alpha =
+         "void main()\n"
+         "{\n"
+-        "	gl_FragColor = dest_swizzle(get_source().a * get_mask());\n"
++        "	frag_color = dest_swizzle(get_source().a * get_mask());\n"
+         "}\n";
+     const char *in_ca_dual_blend =
+         "out vec4 color0;\n"
+@@ -226,10 +226,6 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         "	color0 = dest_swizzle(get_source() * get_mask());\n"
+         "	color1 = dest_swizzle(get_source().a * get_mask());\n"
+         "}\n";
+-    const char *header_ca_dual_blend =
+-        "#version 130\n";
+-    const char *header_ca_dual_blend_gpu_shader4 =
+-        "#version 120\n#extension GL_EXT_gpu_shader4 : require\n";
+     const char *in_ca_dual_blend_gles2 =
+         "void main()\n"
+         "{\n"
+@@ -238,14 +234,16 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         "}\n";
+     const char *header_ca_dual_blend_gles2 =
+         "#version 100\n"
+-        "#extension GL_EXT_blend_func_extended : require\n";
++        "#extension GL_EXT_blend_func_extended : require\n"
++        GLAMOR_COMPAT_DEFINES_FS;
+ 
+     char *source;
+     const char *source_fetch;
+     const char *mask_fetch = "";
+     const char *in;
+     const char *header;
+-    const char *header_norm = "";
++    const char *header_norm = glamor_priv->glsl_version > 120 ? "#version 130\n" : "#version 120\n#extension GL_EXT_gpu_shader4 : require\n" GLAMOR_COMPAT_DEFINES_FS;
++    const char *header_es = glamor_priv->glsl_version > 100 ? "#version 300 es\n" : "#version 100\n" GLAMOR_COMPAT_DEFINES_FS;
+     const char *dest_swizzle;
+     GLuint prog;
+ 
+@@ -298,7 +296,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         FatalError("Bad composite shader dest swizzle");
+     }
+ 
+-    header = header_norm;
++    header = glamor_priv->is_gles ? header_es : header_norm;
+     switch (key->in) {
+     case glamor_program_alpha_normal:
+         in = in_normal;
+@@ -303,10 +300,6 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+         break;
+     case glamor_program_alpha_dual_blend:
+         in = in_ca_dual_blend;
+-        if (glamor_priv->glsl_version >= 130)
+-           header = header_ca_dual_blend;
+-        else
+-           header = header_ca_dual_blend_gpu_shader4;
+         break;
+     case glamor_program_alpha_dual_blend_gles2:
+         in = in_ca_dual_blend_gles2;
+@@ -327,7 +321,8 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+     XNFasprintf(&source,
+                 "%s"
+                 GLAMOR_DEFAULT_PRECISION
+-                "%s%s%s%s%s%s%s", header, repeat_define, relocate_texture,
++                "%s%s%s%s%s%s%s%s", header, GLAMOR_COMPAT_DEFINES_FS,
++                repeat_define, relocate_texture,
+                 rel_sampler, source_fetch, mask_fetch, dest_swizzle, in);
+ 
+     prog = glamor_compile_glsl_prog(GL_FRAGMENT_SHADER, source);
+@@ -337,14 +332,14 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+ }
+ 
+ static GLuint
+-glamor_create_composite_vs(struct shader_key *key)
++glamor_create_composite_vs(glamor_screen_private* priv, struct shader_key *key)
+ {
+     const char *main_opening =
+-        "attribute vec4 v_position;\n"
+-        "attribute vec4 v_texcoord0;\n"
+-        "attribute vec4 v_texcoord1;\n"
+-        "varying vec2 source_texture;\n"
+-        "varying vec2 mask_texture;\n"
++        "in vec4 v_position;\n"
++        "in vec4 v_texcoord0;\n"
++        "in vec4 v_texcoord1;\n"
++        "out vec2 source_texture;\n"
++        "out vec2 mask_texture;\n"
+         "void main()\n"
+         "{\n"
+         "	gl_Position = v_position;\n";
+@@ -354,7 +349,9 @@ glamor_create_composite_vs(struct shader_key *key)
+     const char *source_coords_setup = "";
+     const char *mask_coords_setup = "";
+     const char *version_gles2 = "#version 100\n";
+-    const char *version = "";
++    const char *version_gles3 = "#version 300 es\n";
++    const char *version = priv->glsl_version > 120 ? "#version 130\n" : "#version 120\n";
++    const char *defines = priv->glsl_version > 120 ? "": GLAMOR_COMPAT_DEFINES_VS;
+     char *source;
+     GLuint prog;
+ 
+@@ -364,14 +361,17 @@ glamor_create_composite_vs(struct shader_key *key)
+     if (key->mask != SHADER_MASK_NONE && key->mask != SHADER_MASK_SOLID)
+         mask_coords_setup = mask_coords;
+ 
+-    if (key->in == glamor_program_alpha_dual_blend_gles2)
++    if (priv->is_gles)
+         version = version_gles2;
+ 
++    if (priv->is_gles && priv->glsl_version > 120)
++        version = version_gles3;
++
+     XNFasprintf(&source,
+                 "%s"
+                 GLAMOR_DEFAULT_PRECISION
+-                "%s%s%s%s",
+-                version, main_opening, source_coords_setup,
++                "%s%s%s%s%s",
++                version, defines, main_opening, source_coords_setup,
+                 mask_coords_setup, main_closing);
+ 
+     prog = glamor_compile_glsl_prog(GL_VERTEX_SHADER, source);
+@@ -389,7 +389,7 @@ glamor_create_composite_shader(ScreenPtr screen, struct shader_key *key,
+     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
+ 
+     glamor_make_current(glamor_priv);
+-    vs = glamor_create_composite_vs(key);
++    vs = glamor_create_composite_vs(glamor_priv, key);
+     if (vs == 0)
+         return;
+     fs = glamor_create_composite_fs(glamor_priv, key);
+diff --git a/glamor/glamor_segs.c b/glamor/glamor_segs.c
+index 78c19ec487..7b0108f839 100644
+--- a/glamor/glamor_segs.c
++++ b/glamor/glamor_segs.c
+@@ -27,7 +27,7 @@
+ 
+ static const glamor_facet glamor_facet_poly_segment = {
+     .name = "poly_segment",
+-    .vs_vars = "attribute vec2 primitive;\n",
++    .vs_vars = "in vec2 primitive;\n",
+     .vs_exec = ("       vec2 pos = vec2(0.0,0.0);\n"
+                 GLAMOR_POS(gl_Position, primitive.xy)),
+ };
+diff --git a/glamor/glamor_spans.c b/glamor/glamor_spans.c
+index dfa37dc074..93beb61d51 100644
+--- a/glamor/glamor_spans.c
++++ b/glamor/glamor_spans.c
+@@ -29,7 +29,7 @@ glamor_program  fill_spans_progs[4];
+ static const glamor_facet glamor_facet_fillspans_130 = {
+     .name = "fill_spans",
+     .version = 130,
+-    .vs_vars =  "attribute vec3 primitive;\n",
++    .vs_vars =  "in vec3 primitive;\n",
+     .vs_exec = ("       vec2 pos = vec2(primitive.z,1) * vec2(gl_VertexID&1, (gl_VertexID&2)>>1);\n"
+                 GLAMOR_POS(gl_Position, (primitive.xy + pos))),
+ };
+diff --git a/glamor/glamor_text.c b/glamor/glamor_text.c
+index 5343cc93ba..f1672d4202 100644
+--- a/glamor/glamor_text.c
++++ b/glamor/glamor_text.c
+@@ -221,9 +221,9 @@ glamor_text(DrawablePtr drawable, GCPtr gc,
+ }
+ 
+ static const char vs_vars_text[] =
+-    "attribute vec4 primitive;\n"
+-    "attribute vec2 source;\n"
+-    "varying vec2 glyph_pos;\n";
++    "in vec4 primitive;\n"
++    "in vec2 source;\n"
++    "out vec2 glyph_pos;\n";
+ 
+ static const char vs_exec_text[] =
+     "       vec2 pos = primitive.zw * vec2(gl_VertexID&1, (gl_VertexID&2)>>1);\n"
+@@ -231,7 +231,7 @@ static const char vs_exec_text[] =
+     "       glyph_pos = source + pos;\n";
+ 
+ static const char fs_vars_text[] =
+-    "varying vec2 glyph_pos;\n";
++    "in vec2 glyph_pos;\n";
+ 
+ static const char fs_exec_text[] =
+     "       ivec2 itile_texture = ivec2(glyph_pos);\n"
+@@ -249,9 +249,9 @@ static const char fs_exec_te[] =
+     "       uint texel = texelFetch(font, itile_texture, 0).x;\n"
+     "       uint bit = (texel >> x) & uint(1);\n"
+     "       if (bit == uint(0))\n"
+-    "               gl_FragColor = bg;\n"
++    "               frag_color = bg;\n"
+     "       else\n"
+-    "               gl_FragColor = fg;\n";
++    "               frag_color = fg;\n";
+ 
+ static const glamor_facet glamor_facet_poly_text = {
+     .name = "poly_text",
+@@ -353,7 +353,7 @@ use_image_solid(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+ 
+ static const glamor_facet glamor_facet_image_fill = {
+     .name = "solid",
+-    .fs_exec = "       gl_FragColor = fg;\n",
++    .fs_exec = "       frag_color = fg;\n",
+     .locations = glamor_program_location_fg,
+     .use = use_image_solid,
+ };
+diff --git a/glamor/glamor_xv.c b/glamor/glamor_xv.c
+index a3d6b3bc3c..3467af86f3 100644
+--- a/glamor/glamor_xv.c
++++ b/glamor/glamor_xv.c
+@@ -65,9 +65,9 @@ static const glamor_facet glamor_facet_xv_planar_2 = {
+     .version = 120,
+ 
+     .source_name = "v_texcoord0",
+-    .vs_vars = ("attribute vec2 position;\n"
+-                "attribute vec2 v_texcoord0;\n"
+-                "varying vec2 tcs;\n"),
++    .vs_vars = ("in vec2 position;\n"
++                "in vec2 v_texcoord0;\n"
++                "out vec2 tcs;\n"),
+     .vs_exec = (GLAMOR_POS(gl_Position, position)
+                 "        tcs = v_texcoord0;\n"),
+ 
+@@ -76,18 +76,18 @@ static const glamor_facet glamor_facet_xv_planar_2 = {
+                 "uniform vec4 offsetyco;\n"
+                 "uniform vec4 ucogamma;\n"
+                 "uniform vec4 vco;\n"
+-                "varying vec2 tcs;\n"),
++                "in vec2 tcs;\n"),
+     .fs_exec = (
+                 "        float sample;\n"
+                 "        vec2 sample_uv;\n"
+                 "        vec4 temp1;\n"
+-                "        sample = texture2D(y_sampler, tcs).w;\n"
++                "        sample = texture(y_sampler, tcs).w;\n"
+                 "        temp1.xyz = offsetyco.www * vec3(sample) + offsetyco.xyz;\n"
+-                "        sample_uv = texture2D(u_sampler, tcs).xy;\n"
++                "        sample_uv = texture(u_sampler, tcs).xy;\n"
+                 "        temp1.xyz = ucogamma.xyz * vec3(sample_uv.x) + temp1.xyz;\n"
+                 "        temp1.xyz = clamp(vco.xyz * vec3(sample_uv.y) + temp1.xyz, 0.0, 1.0);\n"
+                 "        temp1.w = 1.0;\n"
+-                "        gl_FragColor = temp1;\n"
++                "        frag_color = temp1;\n"
+                 ),
+ };
+ 
+@@ -97,9 +97,9 @@ static const glamor_facet glamor_facet_xv_planar_3 = {
+     .version = 120,
+ 
+     .source_name = "v_texcoord0",
+-    .vs_vars = ("attribute vec2 position;\n"
+-                "attribute vec2 v_texcoord0;\n"
+-                "varying vec2 tcs;\n"),
++    .vs_vars = ("in vec2 position;\n"
++                "in vec2 v_texcoord0;\n"
++                "out vec2 tcs;\n"),
+     .vs_exec = (GLAMOR_POS(gl_Position, position)
+                 "        tcs = v_texcoord0;\n"),
+ 
+@@ -109,18 +109,18 @@ static const glamor_facet glamor_facet_xv_planar_3 = {
+                 "uniform vec4 offsetyco;\n"
+                 "uniform vec4 ucogamma;\n"
+                 "uniform vec4 vco;\n"
+-                "varying vec2 tcs;\n"),
++                "in vec2 tcs;\n"),
+     .fs_exec = (
+                 "        float sample;\n"
+                 "        vec4 temp1;\n"
+-                "        sample = texture2D(y_sampler, tcs).w;\n"
++                "        sample = texture(y_sampler, tcs).w;\n"
+                 "        temp1.xyz = offsetyco.www * vec3(sample) + offsetyco.xyz;\n"
+-                "        sample = texture2D(u_sampler, tcs).w;\n"
++                "        sample = texture(u_sampler, tcs).w;\n"
+                 "        temp1.xyz = ucogamma.xyz * vec3(sample) + temp1.xyz;\n"
+-                "        sample = texture2D(v_sampler, tcs).w;\n"
++                "        sample = texture(v_sampler, tcs).w;\n"
+                 "        temp1.xyz = clamp(vco.xyz * vec3(sample) + temp1.xyz, 0.0, 1.0);\n"
+                 "        temp1.w = 1.0;\n"
+-                "        gl_FragColor = temp1;\n"
++                "        frag_color = temp1;\n"
+                 ),
+ };
+ 
+-- 
+GitLab
+

--- a/debian/patches/glamor-gles/1004-glamor-Dont-require-EXT_gpu_shader4-unconditionally.patch
+++ b/debian/patches/glamor-gles/1004-glamor-Dont-require-EXT_gpu_shader4-unconditionally.patch
@@ -1,0 +1,32 @@
+From 910847f45265aa1b0177dc4be4d165dc71c01b69 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ball=C3=B3=20Gy=C3=B6rgy?= <ballogyor@gmail.com>
+Date: Wed, 11 Oct 2023 16:01:13 +0200
+Subject: [PATCH] glamor: Don't require EXT_gpu_shader4 unconditionally
+
+It causes a shader compilation error on systems without EXT_gpu_shader4.
+
+Fixes: ee107cd4
+---
+ glamor/glamor_render.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/glamor/glamor_render.c b/glamor/glamor_render.c
+index 99c31fc2c5..179b62dd81 100644
+--- a/glamor/glamor_render.c
++++ b/glamor/glamor_render.c
+@@ -242,7 +242,11 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+     const char *mask_fetch = "";
+     const char *in;
+     const char *header;
+-    const char *header_norm = glamor_priv->glsl_version > 120 ? "#version 130\n" : "#version 120\n#extension GL_EXT_gpu_shader4 : require\n" GLAMOR_COMPAT_DEFINES_FS;
++    const char *header_norm = glamor_priv->glsl_version > 120 ?
++        "#version 130\n" :
++        glamor_priv->use_gpu_shader4 ?
++          "#version 120\n#extension GL_EXT_gpu_shader4 : require\n" GLAMOR_COMPAT_DEFINES_FS :
++          "#version 120\n" GLAMOR_COMPAT_DEFINES_FS;
+     const char *header_es = glamor_priv->glsl_version > 100 ? "#version 300 es\n" : "#version 100\n" GLAMOR_COMPAT_DEFINES_FS;
+     const char *dest_swizzle;
+     GLuint prog;
+-- 
+GitLab
+

--- a/debian/patches/glamor-gles/1005-glamor-Fix-dual-blend-on-GLES3.patch
+++ b/debian/patches/glamor-gles/1005-glamor-Fix-dual-blend-on-GLES3.patch
@@ -1,0 +1,67 @@
+From eba15f1ba75bc041d54693ebc62a8b9957b8b033 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Sat, 14 Dec 2024 01:07:31 +0800
+Subject: [PATCH] glamor: Fix dual blend on GLES3
+
+The EXT_blend_func_extended extension on ESSL always requires explicit
+request to allow two FS out variables because of limitations of the ESSL
+language, which is mentioned as the No.6 issue of the extension's
+specification.
+
+Fix this by adding the extension request.
+
+The original behavior on GLES3 is slightly against the specification of
+GL_EXT_blend_func_extended extension, however Mesa and older version of
+PowerVR closed drivers will just ignore this issue. Newest PowerVR
+closed driver will bail out on this problem, so it deems a fix now.
+
+Fixes: ee107cd4911e ("glamor: support GLES3 shaders")
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1750>
+---
+ glamor/glamor_composite_glyphs.c | 22 +++++++++++++++++++++-
+ 1 file changed, 21 insertions(+), 1 deletion(-)
+
+diff --git a/glamor/glamor_composite_glyphs.c b/glamor/glamor_composite_glyphs.c
+index 428303091d..13af727ffb 100644
+--- a/glamor/glamor_composite_glyphs.c
++++ b/glamor/glamor_composite_glyphs.c
+@@ -178,6 +178,24 @@ glamor_glyph_add(struct glamor_glyph_atlas *atlas, DrawablePtr glyph_draw)
+     return TRUE;
+ }
+ 
++static const glamor_facet glamor_facet_composite_glyphs_es300 = {
++    .name = "composite_glyphs",
++    .version = 130,
++    .fs_extensions = ("#extension GL_EXT_blend_func_extended : enable\n"),
++    .vs_vars = ("in vec4 primitive;\n"
++                "in vec2 source;\n"
++                "out vec2 glyph_pos;\n"),
++    .vs_exec = ("       vec2 pos = primitive.zw * vec2(gl_VertexID&1, (gl_VertexID&2)>>1);\n"
++                GLAMOR_POS(gl_Position, (primitive.xy + pos))
++                "       glyph_pos = (source + pos) * ATLAS_DIM_INV;\n"),
++    .fs_vars = ("in vec2 glyph_pos;\n"
++                "out vec4 color0;\n"
++                "out vec4 color1;\n"),
++    .fs_exec = ("       vec4 mask = texture(atlas, glyph_pos);\n"),
++    .source_name = "source",
++    .locations = glamor_program_location_atlas,
++};
++
+ static const glamor_facet glamor_facet_composite_glyphs_130 = {
+     .name = "composite_glyphs",
+     .version = 130,
+@@ -454,7 +472,9 @@ glamor_composite_glyphs(CARD8 op,
+                         if (glamor_glsl_has_ints(glamor_priv))
+                             prog = glamor_setup_program_render(op, src, glyph_pict, dst,
+                                                                glyphs_program,
+-                                                               &glamor_facet_composite_glyphs_130,
++                                                               glamor_priv->is_gles ?
++                                                                   &glamor_facet_composite_glyphs_es300 :
++                                                                   &glamor_facet_composite_glyphs_130,
+                                                                glamor_priv->glyph_defines);
+                         else
+                             prog = glamor_setup_program_render(op, src, glyph_pict, dst,
+-- 
+GitLab
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -13,3 +13,10 @@ Resolve_xorg_crashing_whith_displaylink_unplugging.patch
 0001-hw-xfree86-workaround-bad-firmware-boot-VGA-reportin.patch
 add-zx-device-id.patch
 add-Glenfly-arise-pci-ids.patch
+#backport: gles support
+glamor-gles/1000-glamor-GLES-fixes-part-1.patch
+glamor-gles/1001-glamor-add-gl_PointSize-for-ES-shaders.patch
+glamor-gles/1002-glamor-handle-EXT_gpu_shader4-in-dual-source-blend-paths.patch
+glamor-gles/1003-glamor-supports-GLES3-shaders.patch
+glamor-gles/1004-glamor-Dont-require-EXT_gpu_shader4-unconditionally.patch
+glamor-gles/1005-glamor-Fix-dual-blend-on-GLES3.patch


### PR DESCRIPTION
  * glamor: GLES fixes, part 1
    (https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1007)
  * glamor: add gl_PointSize for ES shaders
    (https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1156)
  * glamor: handle EXT_gpu_shader4 in dual source blend paths
    (https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1066)
  * glamor: supports GLES3 shaders
    (https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/948)
  * glamor: Don't require EXT_gpu_shader4 unconditionally (fix previous MR)
    (https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1179)
  * glamor: Fix dual blend on GLES3 (fix for PowerVR driver)
    (https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1750)