### PR TITLE
fix: update patch line numbers for quilt 3.0 compatibility

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xorg-server (2:21.1.10-1deepin12) unstable; urgency=medium
+
+  * fix: update patch line numbers for quilt 3.0 compatibility
+
+ -- Liu Heng <liuhenga@uniontech.com>  Mon, 20 Oct 2025 07:01:19 +0000
+
 xorg-server (2:21.1.10-1deepin11) unstable; urgency=medium
 
   * feat: implement screenshot protection for secure windows

--- a/debian/patches/0001-config-Preserve-section-data-when-parsing-duplicate-files.patch
+++ b/debian/patches/0001-config-Preserve-section-data-when-parsing-duplicate-files.patch
@@ -30,11 +30,11 @@ Fixes: https://gitlab.freedesktop.org/xorg/xserver/-/issues/467
  hw/xfree86/parser/read.c        |  6 +++---
  5 files changed, 33 insertions(+), 15 deletions(-)
 
-diff --git a/hw/xfree86/parser/Files.c b/hw/xfree86/parser/Files.c
-index fba99a864..433ec6cbb 100644
---- a/hw/xfree86/parser/Files.c
-+++ b/hw/xfree86/parser/Files.c
-@@ -76,16 +76,22 @@ static const xf86ConfigSymTabRec FilesTab[] = {
+Index: xorg-server/hw/xfree86/parser/Files.c
+===================================================================
+--- xorg-server.orig/hw/xfree86/parser/Files.c
++++ xorg-server/hw/xfree86/parser/Files.c
+@@ -76,16 +76,22 @@ static const xf86ConfigSymTabRec FilesTa
  #define CLEANUP xf86freeFiles
  
  XF86ConfFilesPtr
@@ -60,11 +60,11 @@ index fba99a864..433ec6cbb 100644
          switch (token) {
          case COMMENT:
              ptr->file_comment = xf86addComment(ptr->file_comment, xf86_lex_val.str);
-diff --git a/hw/xfree86/parser/Flags.c b/hw/xfree86/parser/Flags.c
-index 7d35bb7ea..aec11ce14 100644
---- a/hw/xfree86/parser/Flags.c
-+++ b/hw/xfree86/parser/Flags.c
-@@ -84,13 +84,19 @@ static const xf86ConfigSymTabRec ServerFlagsTab[] = {
+Index: xorg-server/hw/xfree86/parser/Flags.c
+===================================================================
+--- xorg-server.orig/hw/xfree86/parser/Flags.c
++++ xorg-server/hw/xfree86/parser/Flags.c
+@@ -84,13 +84,19 @@ static const xf86ConfigSymTabRec ServerF
  #define CLEANUP xf86freeFlags
  
  XF86ConfFlagsPtr
@@ -87,11 +87,11 @@ index 7d35bb7ea..aec11ce14 100644
          int hasvalue = FALSE;
          int strvalue = FALSE;
          int tokentype;
-diff --git a/hw/xfree86/parser/Module.c b/hw/xfree86/parser/Module.c
-index 9a166aff2..95a692af9 100644
---- a/hw/xfree86/parser/Module.c
-+++ b/hw/xfree86/parser/Module.c
-@@ -118,13 +118,19 @@ xf86parseModuleSubSection(XF86LoadPtr head, char *name)
+Index: xorg-server/hw/xfree86/parser/Module.c
+===================================================================
+--- xorg-server.orig/hw/xfree86/parser/Module.c
++++ xorg-server/hw/xfree86/parser/Module.c
+@@ -118,13 +118,19 @@ xf86parseModuleSubSection(XF86LoadPtr he
  }
  
  XF86ConfModulePtr
@@ -114,11 +114,11 @@ index 9a166aff2..95a692af9 100644
          switch (token) {
          case COMMENT:
              ptr->mod_comment = xf86addComment(ptr->mod_comment, xf86_lex_val.str);
-diff --git a/hw/xfree86/parser/configProcs.h b/hw/xfree86/parser/configProcs.h
-index 39399b7bc..2c0abefde 100644
---- a/hw/xfree86/parser/configProcs.h
-+++ b/hw/xfree86/parser/configProcs.h
-@@ -38,12 +38,12 @@ void xf86freeDeviceList(XF86ConfDevicePtr ptr);
+Index: xorg-server/hw/xfree86/parser/configProcs.h
+===================================================================
+--- xorg-server.orig/hw/xfree86/parser/configProcs.h
++++ xorg-server/hw/xfree86/parser/configProcs.h
+@@ -36,12 +36,12 @@ void xf86freeDeviceList(XF86ConfDevicePt
  int xf86validateDevice(XF86ConfigPtr p);
  
  /* Files.c */
@@ -133,7 +133,7 @@ index 39399b7bc..2c0abefde 100644
  void xf86printServerFlagsSection(FILE * f, XF86ConfFlagsPtr flags);
  void xf86freeFlags(XF86ConfFlagsPtr flags);
  
-@@ -68,7 +68,7 @@ void xf86freeLayoutList(XF86ConfLayoutPtr ptr);
+@@ -66,7 +66,7 @@ void xf86freeLayoutList(XF86ConfLayoutPt
  int xf86validateLayout(XF86ConfigPtr p);
  
  /* Module.c */
@@ -142,10 +142,10 @@ index 39399b7bc..2c0abefde 100644
  void xf86printModuleSection(FILE * cf, XF86ConfModulePtr ptr);
  extern _X_EXPORT XF86LoadPtr xf86addNewLoadDirective(XF86LoadPtr head,
                                                       const char *name, int type,
-diff --git a/hw/xfree86/parser/read.c b/hw/xfree86/parser/read.c
-index a4600bc06..e3cbc2115 100644
---- a/hw/xfree86/parser/read.c
-+++ b/hw/xfree86/parser/read.c
+Index: xorg-server/hw/xfree86/parser/read.c
+===================================================================
+--- xorg-server.orig/hw/xfree86/parser/read.c
++++ xorg-server/hw/xfree86/parser/read.c
 @@ -113,12 +113,12 @@ xf86readConfigFile(void)
              if (xf86nameCompare(xf86_lex_val.str, "files") == 0) {
                  free(xf86_lex_val.str);
@@ -170,6 +170,3 @@ index a4600bc06..e3cbc2115 100644
              }
              else if (xf86nameCompare(xf86_lex_val.str, "serverlayout") == 0) {
                  free(xf86_lex_val.str);
--- 
-2.51.0
-

--- a/debian/patches/0001-feat-implement-screenshot-protection-for-secure-wind.patch
+++ b/debian/patches/0001-feat-implement-screenshot-protection-for-secure-wind.patch
@@ -53,11 +53,11 @@ Influence:
  include/window.h |   4 +
  4 files changed, 364 insertions(+), 2 deletions(-)
 
-diff --git a/Xext/shm.c b/Xext/shm.c
-index 071bd1a..747e7d1 100644
---- a/Xext/shm.c
-+++ b/Xext/shm.c
-@@ -60,6 +60,7 @@ in this Software without prior written authorization from The Open Group.
+Index: xorg-server/Xext/shm.c
+===================================================================
+--- xorg-server.orig/Xext/shm.c
++++ xorg-server/Xext/shm.c
+@@ -60,6 +60,7 @@ in this Software without prior written a
  #include <sys/mman.h>
  #include "protocol-versions.h"
  #include "busfault.h"
@@ -94,10 +94,10 @@ index 071bd1a..747e7d1 100644
      WriteToClient(client, sizeof(xShmGetImageReply), &xgi);
  
      return Success;
-diff --git a/dix/dispatch.c b/dix/dispatch.c
-index 8f7452d..93dd6f1 100644
---- a/dix/dispatch.c
-+++ b/dix/dispatch.c
+Index: xorg-server/dix/dispatch.c
+===================================================================
+--- xorg-server.orig/dix/dispatch.c
++++ xorg-server/dix/dispatch.c
 @@ -143,6 +143,9 @@ int ProcInitialConnection();
  #define BITCLEAR(buf, i) MASKWORD(buf, i) &= ~BITMASK(i)
  #define GETBIT(buf, i) (MASKWORD(buf, i) & BITMASK(i))
@@ -455,7 +455,7 @@ index 8f7452d..93dd6f1 100644
  static int
  DoGetImage(ClientPtr client, int format, Drawable drawable,
             int x, int y, int width, int height,
-@@ -2163,6 +2492,7 @@ DoGetImage(ClientPtr client, int format, Drawable drawable,
+@@ -2163,6 +2492,7 @@ DoGetImage(ClientPtr client, int format,
  
      relx = x;
      rely = y;
@@ -463,7 +463,7 @@ index 8f7452d..93dd6f1 100644
  
      if (pDraw->type == DRAWABLE_WINDOW) {
          WindowPtr pWin = (WindowPtr) pDraw;
-@@ -2283,16 +2613,23 @@ DoGetImage(ClientPtr client, int format, Drawable drawable,
+@@ -2283,16 +2613,23 @@ DoGetImage(ClientPtr client, int format,
                                           width,
                                           nlines,
                                           format, planemask, (void *) pBuf);
@@ -489,11 +489,11 @@ index 8f7452d..93dd6f1 100644
              WriteToClient(client, (int) (nlines * widthBytesLine), pBuf);
              linesDone += nlines;
          }
-diff --git a/dix/dispatch.h b/dix/dispatch.h
-index 939a6b9..afad9d3 100644
---- a/dix/dispatch.h
-+++ b/dix/dispatch.h
-@@ -142,4 +142,9 @@ int ProcUninstallColormap(ClientPtr /* client */ );
+Index: xorg-server/dix/dispatch.h
+===================================================================
+--- xorg-server.orig/dix/dispatch.h
++++ xorg-server/dix/dispatch.h
+@@ -142,4 +142,9 @@ int ProcUninstallColormap(ClientPtr /* c
  int ProcUnmapSubwindows(ClientPtr /* client */ );
  int ProcUnmapWindow(ClientPtr /* client */ );
  
@@ -503,11 +503,11 @@ index 939a6b9..afad9d3 100644
 +        xRectangle pRects, unsigned int bgPixel, unsigned int lockPixel);
 +
  #endif                          /* DISPATCH_H */
-diff --git a/include/window.h b/include/window.h
-index 7a22feb..2bbcdc8 100644
---- a/include/window.h
-+++ b/include/window.h
-@@ -232,4 +232,8 @@ extern _X_EXPORT void PrintWindowTree(void);
+Index: xorg-server/include/window.h
+===================================================================
+--- xorg-server.orig/include/window.h
++++ xorg-server/include/window.h
+@@ -232,4 +232,8 @@ extern _X_EXPORT void PrintWindowTree(vo
  extern _X_EXPORT void PrintPassiveGrabs(void);
  
  extern _X_EXPORT VisualPtr WindowGetVisual(WindowPtr /*pWin*/);
@@ -516,6 +516,3 @@ index 7a22feb..2bbcdc8 100644
 +extern _X_EXPORT void RemoveProtectedWindow(Window window);
 +
  #endif                          /* WINDOW_H */
--- 
-2.50.1
-

--- a/debian/patches/0001-hw-xfree86-workaround-bad-firmware-boot-VGA-reportin.patch
+++ b/debian/patches/0001-hw-xfree86-workaround-bad-firmware-boot-VGA-reportin.patch
@@ -34,10 +34,10 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  hw/xfree86/common/xf86Bus.c | 28 ++++++++++++++++++++++++++++
  1 file changed, 28 insertions(+)
 
-diff --git a/hw/xfree86/common/xf86Bus.c b/hw/xfree86/common/xf86Bus.c
-index fd144dbe7..a95096736 100644
---- a/hw/xfree86/common/xf86Bus.c
-+++ b/hw/xfree86/common/xf86Bus.c
+Index: xorg-server/hw/xfree86/common/xf86Bus.c
+===================================================================
+--- xorg-server.orig/hw/xfree86/common/xf86Bus.c
++++ xorg-server/hw/xfree86/common/xf86Bus.c
 @@ -241,6 +241,34 @@ xf86BusProbe(void)
  {
  #ifdef XSERVER_PLATFORM_BUS
@@ -73,6 +73,3 @@ index fd144dbe7..a95096736 100644
      if (ServerIsNotSeat0() && xf86_num_platform_devices > 0)
          return;
  #endif
--- 
-2.48.1
-

--- a/debian/patches/02_kbsd-input-devd.diff
+++ b/debian/patches/02_kbsd-input-devd.diff
@@ -23,8 +23,10 @@ v2 - Emilio Pozuelo Monfort <pochu@debian.org>
  8 files changed, 416 insertions(+), 4 deletions(-)
  create mode 100644 config/devd.c
 
---- a/config/Makefile.am
-+++ b/config/Makefile.am
+Index: xorg-server/config/Makefile.am
+===================================================================
+--- xorg-server.orig/config/Makefile.am
++++ xorg-server/config/Makefile.am
 @@ -34,6 +34,10 @@ if CONFIG_WSCONS
  libconfig_la_SOURCES += wscons.c
  endif # CONFIG_WSCONS
@@ -36,8 +38,10 @@ v2 - Emilio Pozuelo Monfort <pochu@debian.org>
  endif # !CONFIG_HAL
  
  endif # !CONFIG_UDEV
---- a/config/config-backends.h
-+++ b/config/config-backends.h
+Index: xorg-server/config/config-backends.h
+===================================================================
+--- xorg-server.orig/config/config-backends.h
++++ xorg-server/config/config-backends.h
 @@ -44,3 +44,8 @@ void config_hal_fini(void);
  int config_wscons_init(void);
  void config_wscons_fini(void);
@@ -47,8 +51,10 @@ v2 - Emilio Pozuelo Monfort <pochu@debian.org>
 +int config_devd_init(void);
 +void config_devd_fini(void);
 +#endif
---- a/config/config.c
-+++ b/config/config.c
+Index: xorg-server/config/config.c
+===================================================================
+--- xorg-server.orig/config/config.c
++++ xorg-server/config/config.c
 @@ -55,6 +55,9 @@ config_init(void)
  #elif defined(CONFIG_WSCONS)
      if (!config_wscons_init())
@@ -68,8 +74,10 @@ v2 - Emilio Pozuelo Monfort <pochu@debian.org>
  #endif
  }
  
+Index: xorg-server/config/devd.c
+===================================================================
 --- /dev/null
-+++ b/config/devd.c
++++ xorg-server/config/devd.c
 @@ -0,0 +1,375 @@
 +/*
 + * Copyright © 2012 Baptiste Daroussin
@@ -446,8 +454,10 @@ v2 - Emilio Pozuelo Monfort <pochu@debian.org>
 +    RemoveNotifyFd(sock_devd);
 +    close(sock_devd);
 +}
---- a/configure.ac
-+++ b/configure.ac
+Index: xorg-server/configure.ac
+===================================================================
+--- xorg-server.orig/configure.ac
++++ xorg-server/configure.ac
 @@ -563,6 +563,7 @@ AC_ARG_ENABLE(dpms,           AS_HELP_ST
  AC_ARG_ENABLE(config-udev,    AS_HELP_STRING([--enable-config-udev], [Build udev support (default: auto)]), [CONFIG_UDEV=$enableval], [CONFIG_UDEV=auto])
  AC_ARG_ENABLE(config-udev-kms,    AS_HELP_STRING([--enable-config-udev-kms], [Build udev kms support (default: auto)]), [CONFIG_UDEV_KMS=$enableval], [CONFIG_UDEV_KMS=auto])
@@ -487,8 +497,10 @@ v2 - Emilio Pozuelo Monfort <pochu@debian.org>
      AC_MSG_WARN([
               ***********************************************
               Neither HAL nor udev backend will be enabled.
---- a/hw/xfree86/common/xf86Config.c
-+++ b/hw/xfree86/common/xf86Config.c
+Index: xorg-server/hw/xfree86/common/xf86Config.c
+===================================================================
+--- xorg-server.orig/hw/xfree86/common/xf86Config.c
++++ xorg-server/hw/xfree86/common/xf86Config.c
 @@ -1290,15 +1290,18 @@ checkCoreInputDevices(serverLayoutPtr se
      }
  
@@ -510,8 +522,10 @@ v2 - Emilio Pozuelo Monfort <pochu@debian.org>
  #endif
          xf86Msg(X_INFO, "The server relies on %s to provide the list of "
                  "input devices.\n\tIf no devices become available, "
---- a/hw/xfree86/common/xf86Globals.c
-+++ b/hw/xfree86/common/xf86Globals.c
+Index: xorg-server/hw/xfree86/common/xf86Globals.c
+===================================================================
+--- xorg-server.orig/hw/xfree86/common/xf86Globals.c
++++ xorg-server/hw/xfree86/common/xf86Globals.c
 @@ -118,7 +118,8 @@ xf86InfoRec xf86Info = {
      .miscModInDevEnabled = TRUE,
      .miscModInDevAllowNonLocal = FALSE,
@@ -522,8 +536,10 @@ v2 - Emilio Pozuelo Monfort <pochu@debian.org>
      .forceInputDevices = FALSE,
      .autoAddDevices = TRUE,
      .autoEnableDevices = TRUE,
---- a/include/dix-config.h.in
-+++ b/include/dix-config.h.in
+Index: xorg-server/include/dix-config.h.in
+===================================================================
+--- xorg-server.orig/include/dix-config.h.in
++++ xorg-server/include/dix-config.h.in
 @@ -418,6 +418,9 @@
  /* Enable systemd-logind integration */
  #undef SYSTEMD_LOGIND 1

--- a/debian/patches/03_static-nettle.diff
+++ b/debian/patches/03_static-nettle.diff
@@ -6,8 +6,10 @@ There's no libnettle udeb.
  configure.ac |    2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
---- a/configure.ac
-+++ b/configure.ac
+Index: xorg-server/configure.ac
+===================================================================
+--- xorg-server.orig/configure.ac
++++ xorg-server/configure.ac
 @@ -1582,7 +1582,7 @@ fi
  if test "x$with_sha1" = xlibnettle; then
  	AC_DEFINE([HAVE_SHA1_IN_LIBNETTLE], [1],

--- a/debian/patches/05_Revert-Unload-submodules.diff
+++ b/debian/patches/05_Revert-Unload-submodules.diff
@@ -10,8 +10,10 @@ This doesn't seem to work quite well.  See Debian bug#686152.
  hw/xfree86/common/xf86Helper.c |    6 ++++++
  1 file changed, 6 insertions(+)
 
---- a/hw/xfree86/common/xf86Helper.c
-+++ b/hw/xfree86/common/xf86Helper.c
+Index: xorg-server/hw/xfree86/common/xf86Helper.c
+===================================================================
+--- xorg-server.orig/hw/xfree86/common/xf86Helper.c
++++ xorg-server/hw/xfree86/common/xf86Helper.c
 @@ -1508,7 +1508,13 @@ xf86LoadOneModule(const char *name, void
  void
  xf86UnloadSubModule(void *mod)

--- a/debian/patches/06_use-intel-only-on-pre-gen4.diff
+++ b/debian/patches/06_use-intel-only-on-pre-gen4.diff
@@ -1,8 +1,10 @@
 Description: Use intel ddx only on pre-gen4 hw, newer ones will fall back to modesetting
 Author: Timo Aaltonen <tjaalton@debian.org>
 
---- a/hw/xfree86/common/xf86pciBus.c
-+++ b/hw/xfree86/common/xf86pciBus.c
+Index: xorg-server/hw/xfree86/common/xf86pciBus.c
+===================================================================
+--- xorg-server.orig/hw/xfree86/common/xf86pciBus.c
++++ xorg-server/hw/xfree86/common/xf86pciBus.c
 @@ -1174,7 +1174,23 @@ xf86VideoPtrToDriverList(struct pci_devi
  		case 0x0bef:
  			/* Use fbdev/vesa driver on Oaktrail, Medfield, CDV */

--- a/debian/patches/07_use-modesetting-driver-by-default-on-GeForce.diff
+++ b/debian/patches/07_use-modesetting-driver-by-default-on-GeForce.diff
@@ -9,8 +9,10 @@ Signed-off-by: Ben Skeggs <bskeggs@redhat.com>
  hw/xfree86/common/xf86pciBus.c | 20 ++++++++++++++++++++
  1 file changed, 20 insertions(+)
 
---- a/hw/xfree86/common/xf86pciBus.c
-+++ b/hw/xfree86/common/xf86pciBus.c
+Index: xorg-server/hw/xfree86/common/xf86pciBus.c
+===================================================================
+--- xorg-server.orig/hw/xfree86/common/xf86pciBus.c
++++ xorg-server/hw/xfree86/common/xf86pciBus.c
 @@ -37,6 +37,9 @@
  #include <unistd.h>
  #include <X11/X.h>

--- a/debian/patches/08_apple_silicon_config.diff
+++ b/debian/patches/08_apple_silicon_config.diff
@@ -11,10 +11,10 @@ Suggested-by: Hector Martin <marcan@marcan.st>
  config/10-quirks.conf | 10 ++++++++++
  1 file changed, 10 insertions(+)
 
-diff --git a/config/10-quirks.conf b/config/10-quirks.conf
-index 47907d8..54dd908 100644
---- a/config/10-quirks.conf
-+++ b/config/10-quirks.conf
+Index: xorg-server/config/10-quirks.conf
+===================================================================
+--- xorg-server.orig/config/10-quirks.conf
++++ xorg-server/config/10-quirks.conf
 @@ -36,3 +36,13 @@ Section "InputClass"
          MatchDriver "evdev"
          Option "TypeName" "MOUSE"

--- a/debian/patches/Resolve_xorg_crashing_whith_displaylink_unplugging.patch
+++ b/debian/patches/Resolve_xorg_crashing_whith_displaylink_unplugging.patch
@@ -1,7 +1,7 @@
-diff --git a/hw/xfree86/common/xf86DGA.c b/hw/xfree86/common/xf86DGA.c
-index fa70ba2..b38b30f 100644
---- a/hw/xfree86/common/xf86DGA.c
-+++ b/hw/xfree86/common/xf86DGA.c
+Index: xorg-server/hw/xfree86/common/xf86DGA.c
+===================================================================
+--- xorg-server.orig/hw/xfree86/common/xf86DGA.c
++++ xorg-server/hw/xfree86/common/xf86DGA.c
 @@ -268,7 +268,8 @@ DGACloseScreen(ScreenPtr pScreen)
      DGAScreenPtr pScreenPriv = DGA_GET_SCREEN_PRIV(pScreen);
  

--- a/debian/patches/add-Glenfly-arise-pci-ids.patch
+++ b/debian/patches/add-Glenfly-arise-pci-ids.patch
@@ -1,8 +1,8 @@
-diff --git a/hw/xfree86/common/xf86pciBus.c b/hw/xfree86/common/xf86pciBus.c
-index 3b6363a..cdfb93b 100644
---- a/hw/xfree86/common/xf86pciBus.c
-+++ b/hw/xfree86/common/xf86pciBus.c
-@@ -1328,6 +1328,17 @@ xf86VideoPtrToDriverList(struct pci_device *dev, XF86MatchedDrivers *md)
+Index: xorg-server/hw/xfree86/common/xf86pciBus.c
+===================================================================
+--- xorg-server.orig/hw/xfree86/common/xf86pciBus.c
++++ xorg-server/hw/xfree86/common/xf86pciBus.c
+@@ -1328,6 +1328,17 @@ xf86VideoPtrToDriverList(struct pci_devi
              break;
          }
          break;

--- a/debian/patches/add-device-id.patch
+++ b/debian/patches/add-device-id.patch
@@ -1,6 +1,8 @@
 
---- xorg-server-21.1.10.orig/hw/xfree86/common/xf86pciBus.c
-+++ xorg-server-21.1.10/hw/xfree86/common/xf86pciBus.c
+Index: xorg-server/hw/xfree86/common/xf86pciBus.c
+===================================================================
+--- xorg-server.orig/hw/xfree86/common/xf86pciBus.c
++++ xorg-server/hw/xfree86/common/xf86pciBus.c
 @@ -1302,6 +1302,24 @@ xf86VideoPtrToDriverList(struct pci_devi
          else
              driverList[0] = "xgi";

--- a/debian/patches/add-zx-device-id.patch
+++ b/debian/patches/add-zx-device-id.patch
@@ -1,8 +1,8 @@
-diff --git a/hw/xfree86/common/xf86pciBus.c b/hw/xfree86/common/xf86pciBus.c
-index c6ecac1..3b6363a 100644
---- a/hw/xfree86/common/xf86pciBus.c
-+++ b/hw/xfree86/common/xf86pciBus.c
-@@ -1311,15 +1311,23 @@ xf86VideoPtrToDriverList(struct pci_device *dev, XF86MatchedDrivers *md)
+Index: xorg-server/hw/xfree86/common/xf86pciBus.c
+===================================================================
+--- xorg-server.orig/hw/xfree86/common/xf86pciBus.c
++++ xorg-server/hw/xfree86/common/xf86pciBus.c
+@@ -1311,15 +1311,23 @@ xf86VideoPtrToDriverList(struct pci_devi
          break;
      case 0x1d17:
          switch (dev->device_id) {

--- a/debian/patches/feat-Xrecord-add-touch-support.patch
+++ b/debian/patches/feat-Xrecord-add-touch-support.patch
@@ -13,11 +13,11 @@ Bug: https://pms.uniontech.com/zentao/bug-view-87450.html
  dix/eventconvert.c | 87 ++++++++++++++++++++++++++++++++++++++++++++--
  2 files changed, 97 insertions(+), 3 deletions(-)
 
-diff --git a/Xi/exevents.c b/Xi/exevents.c
-index 54ea11a..902e8e4 100644
---- a/Xi/exevents.c
-+++ b/Xi/exevents.c
-@@ -1622,6 +1622,19 @@ ProcessTouchEvent(InternalEvent *ev, DeviceIntPtr dev)
+Index: xorg-server/Xi/exevents.c
+===================================================================
+--- xorg-server.orig/Xi/exevents.c
++++ xorg-server/Xi/exevents.c
+@@ -1623,6 +1623,19 @@ ProcessTouchEvent(InternalEvent *ev, Dev
      else
          ti = TouchFindByClientID(dev, touchid);
  
@@ -37,10 +37,10 @@ index 54ea11a..902e8e4 100644
      /* Active pointer grab */
      if (emulate_pointer && dev->deviceGrab.grab && !dev->deviceGrab.fromPassiveGrab &&
          (dev->deviceGrab.grab->grabtype == CORE ||
-diff --git a/dix/eventconvert.c b/dix/eventconvert.c
-index 53b8c79..b34b9c4 100644
---- a/dix/eventconvert.c
-+++ b/dix/eventconvert.c
+Index: xorg-server/dix/eventconvert.c
+===================================================================
+--- xorg-server.orig/dix/eventconvert.c
++++ xorg-server/dix/eventconvert.c
 @@ -32,6 +32,18 @@
  #include <dix-config.h>
  #endif
@@ -60,7 +60,7 @@ index 53b8c79..b34b9c4 100644
  #include <stdint.h>
  #include <X11/X.h>
  #include <X11/extensions/XIproto.h>
-@@ -159,9 +171,6 @@ EventToCore(InternalEvent *event, xEvent **core_out, int *count_out)
+@@ -159,9 +171,6 @@ EventToCore(InternalEvent *event, xEvent
      case ET_RawTouchBegin:
      case ET_RawTouchUpdate:
      case ET_RawTouchEnd:
@@ -70,7 +70,7 @@ index 53b8c79..b34b9c4 100644
      case ET_TouchOwnership:
      case ET_BarrierHit:
      case ET_BarrierLeave:
-@@ -173,6 +182,78 @@ EventToCore(InternalEvent *event, xEvent **core_out, int *count_out)
+@@ -173,6 +182,78 @@ EventToCore(InternalEvent *event, xEvent
      case ET_GestureSwipeEnd:
          ret = BadMatch;
          break;
@@ -149,6 +149,3 @@ index 53b8c79..b34b9c4 100644
      default:
          /* XXX: */
          ErrorF("[dix] EventToCore: Not implemented yet \n");
--- 
-2.20.1
-

--- a/debian/patches/glamor-gles/1000-glamor-GLES-fixes-part-1.patch
+++ b/debian/patches/glamor-gles/1000-glamor-GLES-fixes-part-1.patch
@@ -17,11 +17,10 @@ Reviewed-by: Emma Anholt <emma@anholt.net>
  create mode 100644 test/bugs/meson.build
  create mode 100755 test/scripts/xephyr-glamor-gles2-piglit.sh
 
-diff --git a/test/bugs/bug1354.c b/test/bugs/bug1354.c
-new file mode 100644
-index 0000000000..edc3f228c2
+Index: xorg-server/test/bugs/bug1354.c
+===================================================================
 --- /dev/null
-+++ b/test/bugs/bug1354.c
++++ xorg-server/test/bugs/bug1354.c
 @@ -0,0 +1,149 @@
 +#include <xcb/xcb.h>
 +#include <xcb/xcb_aux.h>
@@ -172,12 +171,11 @@ index 0000000000..edc3f228c2
 +	}
 +	return result == 3 ? 0 : 1;
 +}
-diff --git a/test/bugs/meson.build b/test/bugs/meson.build
-new file mode 100644
-index 0000000000..1f5305f56f
+Index: xorg-server/test/bugs/meson.build
+===================================================================
 --- /dev/null
-+++ b/test/bugs/meson.build
-@@ -0,0 +1,51 @@
++++ xorg-server/test/bugs/meson.build
+@@ -0,0 +1,50 @@
 +xcb_dep = dependency('xcb', required: false)
 +xcb_image_dep = dependency('xcb-image', required: false)
 +xcb_util_dep = dependency('xcb-util', required: false)
@@ -225,16 +223,15 @@ index 0000000000..1f5305f56f
 +                    ],
 +                suite: 'xephyr-glamor-gles2',
 +                timeout: 300,
-+                should_fail: true,
 +            )
 +    endif
 +endif
 \ No newline at end of file
-diff --git a/test/meson.build b/test/meson.build
-index a8d9e84973..662eee4ef3 100644
---- a/test/meson.build
-+++ b/test/meson.build
-@@ -9,13 +9,24 @@ piglit_env.set('XSERVER_DIR', meson.source_root())
+Index: xorg-server/test/meson.build
+===================================================================
+--- xorg-server.orig/test/meson.build
++++ xorg-server/test/meson.build
+@@ -9,13 +9,24 @@ piglit_env.set('XSERVER_DIR', meson.sour
  piglit_env.set('XSERVER_BUILDDIR', meson.build_root())
  
  some_ops = ' -o clear,src,dst,over,xor,disjointover'
@@ -286,7 +283,7 @@ index a8d9e84973..662eee4ef3 100644
  if get_option('xvfb')
 @@ -76,6 +99,12 @@ if get_option('xvfb')
              timeout: 1200,
-             suite: 'xephyr-glamor',
+             suite: 'xephr-glamor',
          )
 +        test('XTS',
 +            find_program('scripts/xephyr-glamor-gles2-piglit.sh'),
@@ -322,7 +319,7 @@ index a8d9e84973..662eee4ef3 100644
          endif
      endif
  endif
-@@ -116,6 +163,7 @@ endif
+@@ -103,6 +150,7 @@ endif
  subdir('bigreq')
  subdir('damage')
  subdir('sync')
@@ -330,11 +327,10 @@ index a8d9e84973..662eee4ef3 100644
  
  if build_xorg
  # Tests that require at least some DDX functions in order to fully link
-diff --git a/test/scripts/xephyr-glamor-gles2-piglit.sh b/test/scripts/xephyr-glamor-gles2-piglit.sh
-new file mode 100755
-index 0000000000..59ca12d263
+Index: xorg-server/test/scripts/xephyr-glamor-gles2-piglit.sh
+===================================================================
 --- /dev/null
-+++ b/test/scripts/xephyr-glamor-gles2-piglit.sh
++++ xorg-server/test/scripts/xephyr-glamor-gles2-piglit.sh
 @@ -0,0 +1,34 @@
 +#!/bin/sh
 +
@@ -370,73 +366,11 @@ index 0000000000..59ca12d263
 +        -- \
 +        $XSERVER_BUILDDIR/hw/vfb/Xvfb \
 +        -screen scrn 1280x1024x24
--- 
-GitLab
-
-
-From 24cd5f34f8edcc6621ed9c0f2b1a3df08de7488d Mon Sep 17 00:00:00 2001
-From: Konstantin <ria.freelander@gmail.com>
-Date: Sun, 26 Jun 2022 00:01:54 +0300
-Subject: [PATCH 2/6] glamor: make use of GL_EXT_texture_format_BGRA8888
-
-For 24 and 32 bit depth pictures xserver uses PICT_x8r8g8b8 and PICT_a8r8g8b8 formats,
-which must be backed with GL_BGRA format. It is present in OpenGL ES 2.0 only with
-GL_EXT_texture_format_BGRA8888 extension. We require such extension in glamor_init,
-so, why not to make use of it?
-Fixes #1208
-Fixes #1354
-
-Signed-off-by: Konstantin Pugin <ria.freelander@gmail.com>
-
-Reviewed-by: Adam Jackson <ajax@redhat.com>
-Reviewed-by: Emma Anholt <emma@anholt.net>
----
- glamor/glamor.c         | 8 ++++----
- glamor/glamor_picture.c | 7 ++-----
- test/bugs/meson.build   | 1 -
- 3 files changed, 6 insertions(+), 10 deletions(-)
-
-diff --git a/test/bugs/meson.build b/test/bugs/meson.build
-index 1f5305f56f..470706d565 100644
---- a/test/bugs/meson.build
-+++ b/test/bugs/meson.build
-@@ -45,7 +45,6 @@ if get_option('xvfb')
-                     ],
-                 suite: 'xephyr-glamor-gles2',
-                 timeout: 300,
--                should_fail: true,
-             )
-     endif
- endif
-\ No newline at end of file
--- 
-GitLab
-
-
-From a59531533fb8fd137d21e0578909d8e91c28dff6 Mon Sep 17 00:00:00 2001
-From: Konstantin <ria.freelander@gmail.com>
-Date: Sat, 25 Jun 2022 17:51:15 +0300
-Subject: [PATCH 3/6] glamor: transpose gradients transparently
-
-glUniformMatrix3fv is used with argument transpose set to GL_TRUE.
-According to the Khronos OpenGL ES 2.0 pages transpose must be GL_FALSE.
-Actually we can just return transformed matrix from
-_glamor_gradient_convert_trans_matrix (@anholt suggest),
-so @uvas workaround is not required
-
-Signed-off-by: Konstantin Pugin <ria.freelander@gmail.com>
-
-Reviewed-by: Adam Jackson <ajax@redhat.com>
-Reviewed-by: Emma Anholt <emma@anholt.net>
----
- glamor/glamor_gradient.c | 32 +++++++++++++++++++++-----------
- 1 file changed, 21 insertions(+), 11 deletions(-)
-
-diff --git a/glamor/glamor_gradient.c b/glamor/glamor_gradient.c
-index 7e5d5cca9f..4c7ae4d77c 100644
---- a/glamor/glamor_gradient.c
-+++ b/glamor/glamor_gradient.c
-@@ -605,27 +605,35 @@ _glamor_gradient_convert_trans_matrix(PictTransform *from, float to[3][3],
+Index: xorg-server/glamor/glamor_gradient.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_gradient.c
++++ xorg-server/glamor/glamor_gradient.c
+@@ -605,27 +605,35 @@ _glamor_gradient_convert_trans_matrix(Pi
       * T_s = | w*t21/h  t22      t23/h|
       *       | w*t31    h*t32    t33  |
       *       --                      --
@@ -479,7 +413,7 @@ index 7e5d5cca9f..4c7ae4d77c 100644
             to[0][0], to[0][1], to[0][2],
             to[1][0], to[1][1], to[1][2], to[2][0], to[2][1], to[2][2]);
  }
-@@ -950,11 +958,12 @@ glamor_generate_radial_gradient_picture(ScreenPtr screen,
+@@ -950,11 +958,12 @@ glamor_generate_radial_gradient_picture(
          _glamor_gradient_convert_trans_matrix(src_picture->transform,
                                                transform_mat, width, height, 0);
          glUniformMatrix3fv(transform_mat_uniform_location,
@@ -494,7 +428,7 @@ index 7e5d5cca9f..4c7ae4d77c 100644
      }
  
      if (!_glamor_gradient_set_pixmap_destination
-@@ -1266,11 +1275,12 @@ glamor_generate_linear_gradient_picture(ScreenPtr screen,
+@@ -1266,11 +1275,12 @@ glamor_generate_linear_gradient_picture(
          _glamor_gradient_convert_trans_matrix(src_picture->transform,
                                                transform_mat, width, height, 1);
          glUniformMatrix3fv(transform_mat_uniform_location,
@@ -509,34 +443,11 @@ index 7e5d5cca9f..4c7ae4d77c 100644
      }
  
      if (!_glamor_gradient_set_pixmap_destination
--- 
-GitLab
-
-
-From 65392d27d77fbdb66e874ba3e2d85dbcf46e4583 Mon Sep 17 00:00:00 2001
-From: Yuriy <uuvasiliev@yandex.ru>
-Date: Thu, 16 Sep 2021 14:47:44 +0300
-Subject: [PATCH 4/6] glamor: fix CbCr format handling
-
-In GLES2, we cannot do GL_RED or GL_RG without GL_EXT_texture_rg.
-So, add check for GL_EXT_texture_rg to make it working. Also add
-a yuv2 pixman format into render.h to make Xv yuv rendering works.
-
-Signed-off-by: Yuriy Vasilev <uuvasiliev@yandex.ru>
-
-Reviewed-by: Adam Jackson <ajax@redhat.com>
-Reviewed-by: Emma Anholt <emma@anholt.net>
----
- glamor/glamor.c      | 19 +++++++++++++++----
- glamor/glamor_priv.h |  1 +
- render/picture.h     |  5 ++++-
- 3 files changed, 20 insertions(+), 5 deletions(-)
-
-diff --git a/glamor/glamor.c b/glamor/glamor.c
-index 0a757db356..c6bb01d8e9 100644
---- a/glamor/glamor.c
-+++ b/glamor/glamor.c
-@@ -223,7 +223,7 @@ glamor_create_pixmap(ScreenPtr screen, int w, int h, int depth,
+Index: xorg-server/glamor/glamor.c
+===================================================================
+--- xorg-server.orig/glamor/glamor.c
++++ xorg-server/glamor/glamor.c
+@@ -223,7 +223,7 @@ glamor_create_pixmap(ScreenPtr screen, i
  
      pixmap_priv = glamor_get_pixmap_private(pixmap);
  
@@ -573,77 +484,7 @@ index 0a757db356..c6bb01d8e9 100644
      glamor_priv->cbcr_format.type = GL_UNSIGNED_BYTE;
      glamor_priv->cbcr_format.rendering_supported = TRUE;
  }
-@@ -787,6 +793,11 @@ glamor_init(ScreenPtr screen, unsigned int flags)
-     glamor_priv->has_clear_texture =
-         epoxy_gl_version() >= 44 ||
-         epoxy_has_gl_extension("GL_ARB_clear_texture");
-+    /* GL_EXT_texture_rg is part of GLES3 core */
-+    glamor_priv->has_rg =
-+        (glamor_priv->is_gles && epoxy_gl_version() >= 30) ||
-+        epoxy_has_gl_extension("GL_EXT_texture_rg") ||
-+        epoxy_has_gl_extension("GL_ARB_texture_rg");
- 
-     glamor_priv->can_copyplane = (gl_version >= 30);
- 
-diff --git a/glamor/glamor_priv.h b/glamor/glamor_priv.h
-index 028a6d3740..da20bc5aa6 100644
---- a/glamor/glamor_priv.h
-+++ b/glamor/glamor_priv.h
-@@ -216,6 +216,7 @@ typedef struct glamor_screen_private {
-     Bool has_dual_blend;
-     Bool has_clear_texture;
-     Bool has_texture_swizzle;
-+    Bool has_rg;
-     Bool is_core_profile;
-     Bool can_copyplane;
-     Bool use_gpu_shader4;
-diff --git a/render/picture.h b/render/picture.h
-index 4499a0021c..c3a73d1d8d 100644
---- a/render/picture.h
-+++ b/render/picture.h
-@@ -125,7 +125,10 @@ typedef enum _PictFormatShort {
- /* 1bpp formats */
-     PICT_a1 = PIXMAN_a1,
- 
--    PICT_g1 = PIXMAN_g1
-+    PICT_g1 = PIXMAN_g1,
-+
-+/* YCbCr formats */
-+    PICT_yuv2 = PIXMAN_yuy2
- } PictFormatShort;
- 
- /*
--- 
-GitLab
-
-
-From 05b8401eeb263e1395aa5ceeb8b5cdbeb0585db6 Mon Sep 17 00:00:00 2001
-From: Vasily Khoruzhick <anarsoul@gmail.com>
-Date: Fri, 27 May 2022 18:00:56 -0700
-Subject: [PATCH 5/6] glamor: use dual source blend on GL 2.1 with
- ARB_ES2_compatibility
-
-ARB_blend_func_extended may be exposed even without GLSL 1.30.
-In order to use it we need GLES2 shaders that are available if
-ARB_ES2_compatibility is exposed.
-
-Signed-off-by: Vasily Khoruzhick <anarsoul@gmail.com>
-
-Reviewed-by: Adam Jackson <ajax@redhat.com>
-Reviewed-by: Emma Anholt <emma@anholt.net>
----
- glamor/glamor.c                  |  6 ++++--
- glamor/glamor_composite_glyphs.c | 20 +++++++++++++++++++-
- glamor/glamor_program.c          | 23 ++++++++++++++++-------
- glamor/glamor_program.h          |  5 +++--
- glamor/glamor_render.c           | 32 ++++++++++++++++++++++++++++----
- 5 files changed, 70 insertions(+), 16 deletions(-)
-
-diff --git a/glamor/glamor.c b/glamor/glamor.c
-index c6bb01d8e9..f15b5a18a3 100644
---- a/glamor/glamor.c
-+++ b/glamor/glamor.c
-@@ -788,8 +788,10 @@ glamor_init(ScreenPtr screen, unsigned int flags)
+@@ -810,11 +816,18 @@ glamor_init(ScreenPtr screen, unsigned i
          epoxy_gl_version() >= 30 ||
          epoxy_has_gl_extension("GL_NV_pack_subimage");
      glamor_priv->has_dual_blend =
@@ -656,11 +497,47 @@ index c6bb01d8e9..f15b5a18a3 100644
      glamor_priv->has_clear_texture =
          epoxy_gl_version() >= 44 ||
          epoxy_has_gl_extension("GL_ARB_clear_texture");
-diff --git a/glamor/glamor_composite_glyphs.c b/glamor/glamor_composite_glyphs.c
-index 147e3bb31a..c69b940d40 100644
---- a/glamor/glamor_composite_glyphs.c
-+++ b/glamor/glamor_composite_glyphs.c
-@@ -208,6 +208,22 @@ static const glamor_facet glamor_facet_composite_glyphs_120 = {
++    /* GL_EXT_texture_rg is part of GLES3 core */
++    glamor_priv->has_rg =
++        (glamor_priv->is_gles && epoxy_gl_version() >= 30) ||
++        epoxy_has_gl_extension("GL_EXT_texture_rg") ||
++        epoxy_has_gl_extension("GL_ARB_texture_rg");
+ 
+     glamor_priv->can_copyplane = (gl_version >= 30);
+ 
+Index: xorg-server/glamor/glamor_priv.h
+===================================================================
+--- xorg-server.orig/glamor/glamor_priv.h
++++ xorg-server/glamor/glamor_priv.h
+@@ -216,6 +216,7 @@ typedef struct glamor_screen_private {
+     Bool has_dual_blend;
+     Bool has_clear_texture;
+     Bool has_texture_swizzle;
++    Bool has_rg;
+     Bool is_core_profile;
+     Bool can_copyplane;
+     Bool use_gpu_shader4;
+Index: xorg-server/render/picture.h
+===================================================================
+--- xorg-server.orig/render/picture.h
++++ xorg-server/render/picture.h
+@@ -125,7 +125,10 @@ typedef enum _PictFormatShort {
+ /* 1bpp formats */
+     PICT_a1 = PIXMAN_a1,
+ 
+-    PICT_g1 = PIXMAN_g1
++    PICT_g1 = PIXMAN_g1,
++
++/* YCbCr formats */
++    PICT_yuv2 = PIXMAN_yuy2
+ } PictFormatShort;
+ 
+ /*
+Index: xorg-server/glamor/glamor_composite_glyphs.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_composite_glyphs.c
++++ xorg-server/glamor/glamor_composite_glyphs.c
+@@ -208,6 +208,22 @@ static const glamor_facet glamor_facet_c
      .locations = glamor_program_location_atlas,
  };
  
@@ -694,10 +571,10 @@ index 147e3bb31a..c69b940d40 100644
                                                                 glamor_priv->glyph_defines);
                          if (!prog)
                              goto bail_one;
-diff --git a/glamor/glamor_program.c b/glamor/glamor_program.c
-index d8ddb4c773..46a506aafe 100644
---- a/glamor/glamor_program.c
-+++ b/glamor/glamor_program.c
+Index: xorg-server/glamor/glamor_program.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_program.c
++++ xorg-server/glamor/glamor_program.c
 @@ -201,6 +201,8 @@ static const char vs_template[] =
  static const char fs_template[] =
      "%s"                                /* version */
@@ -707,7 +584,19 @@ index d8ddb4c773..46a506aafe 100644
      GLAMOR_DEFAULT_PRECISION
      "%s"                                /* defines */
      "%s"                                /* prim fs_vars */
-@@ -312,6 +314,8 @@ glamor_build_program(ScreenPtr          screen,
+@@ -281,6 +283,11 @@ glamor_build_program(ScreenPtr
+             gpu_shader4 = TRUE;
+         }
+     }
++    /* For now, fix shader version to GLES as 100. We will fall with 130 shaders
++     * in previous check due to forcibly set 120 glsl for GLES. But this patch
++     * makes xv shaders to work */
++    if(version && glamor_priv->is_gles)
++        version = 100;
+ 
+     vs_vars = vs_location_vars(locations);
+     fs_vars = fs_location_vars(locations);
+@@ -312,6 +319,8 @@ glamor_build_program(ScreenPtr
      if (asprintf(&fs_prog_string,
                   fs_template,
                   str(version_string),
@@ -716,7 +605,7 @@ index d8ddb4c773..46a506aafe 100644
                   gpu_shader4 ? "#extension GL_EXT_gpu_shader4 : require\n#define texelFetch texelFetch2D\n#define uint unsigned int\n" : "",
                   str(defines),
                   str(prim->fs_vars),
-@@ -494,7 +498,8 @@ glamor_set_blend(CARD8 op, glamor_program_alpha alpha, PicturePtr dst)
+@@ -494,7 +503,8 @@ glamor_set_blend(CARD8 op, glamor_progra
      }
  
      /* Set up the source alpha value for blending in component alpha mode. */
@@ -726,7 +615,7 @@ index d8ddb4c773..46a506aafe 100644
          switch (dst_blend) {
          case GL_SRC_ALPHA:
              dst_blend = GL_SRC1_COLOR;
-@@ -581,11 +586,13 @@ static const glamor_facet *glamor_facet_source[glamor_program_source_count] = {
+@@ -581,11 +591,13 @@ static const glamor_facet *glamor_facet_
  };
  
  static const char *glamor_combine[] = {
@@ -745,7 +634,7 @@ index d8ddb4c773..46a506aafe 100644
  };
  
  static Bool
-@@ -633,7 +640,9 @@ glamor_setup_program_render(CARD8                 op,
+@@ -633,7 +645,9 @@ glamor_setup_program_render(CARD8
  
      if (glamor_is_component_alpha(mask)) {
          if (glamor_priv->has_dual_blend) {
@@ -756,10 +645,10 @@ index d8ddb4c773..46a506aafe 100644
          } else {
              /* This only works for PictOpOver */
              if (op != PictOpOver)
-diff --git a/glamor/glamor_program.h b/glamor/glamor_program.h
-index ab6e46f7b5..0bd918fff3 100644
---- a/glamor/glamor_program.h
-+++ b/glamor/glamor_program.h
+Index: xorg-server/glamor/glamor_program.h
+===================================================================
+--- xorg-server.orig/glamor/glamor_program.h
++++ xorg-server/glamor/glamor_program.h
 @@ -44,6 +44,7 @@ typedef enum {
      glamor_program_alpha_ca_first,
      glamor_program_alpha_ca_second,
@@ -768,7 +657,7 @@ index ab6e46f7b5..0bd918fff3 100644
      glamor_program_alpha_count
  } glamor_program_alpha;
  
-@@ -56,8 +57,8 @@ typedef Bool (*glamor_use_render) (CARD8 op, PicturePtr src, PicturePtr dst, gla
+@@ -56,8 +57,8 @@ typedef Bool (*glamor_use_render) (CARD8
  typedef struct {
      const char                          *name;
      const int                           version;
@@ -779,11 +668,11 @@ index ab6e46f7b5..0bd918fff3 100644
      const char                          *vs_vars;
      const char                          *vs_exec;
      const char                          *fs_vars;
-diff --git a/glamor/glamor_render.c b/glamor/glamor_render.c
-index 2af65bf936..c9a125ef9d 100644
---- a/glamor/glamor_render.c
-+++ b/glamor/glamor_render.c
-@@ -223,6 +223,15 @@ glamor_create_composite_fs(struct shader_key *key)
+Index: xorg-server/glamor/glamor_render.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_render.c
++++ xorg-server/glamor/glamor_render.c
+@@ -223,6 +223,15 @@ glamor_create_composite_fs(struct shader
          "}\n";
      const char *header_ca_dual_blend =
          "#version 130\n";
@@ -799,7 +688,7 @@ index 2af65bf936..c9a125ef9d 100644
  
      char *source;
      const char *source_fetch;
-@@ -294,6 +303,10 @@ glamor_create_composite_fs(struct shader_key *key)
+@@ -294,6 +303,10 @@ glamor_create_composite_fs(struct shader
          in = in_ca_dual_blend;
          header = header_ca_dual_blend;
          break;
@@ -810,7 +699,7 @@ index 2af65bf936..c9a125ef9d 100644
      default:
          FatalError("Bad composite IN type");
      }
-@@ -327,6 +340,8 @@ glamor_create_composite_vs(struct shader_key *key)
+@@ -327,6 +340,8 @@ glamor_create_composite_vs(struct shader
      const char *main_closing = "}\n";
      const char *source_coords_setup = "";
      const char *mask_coords_setup = "";
@@ -819,7 +708,7 @@ index 2af65bf936..c9a125ef9d 100644
      char *source;
      GLuint prog;
  
-@@ -336,10 +351,15 @@ glamor_create_composite_vs(struct shader_key *key)
+@@ -336,10 +351,15 @@ glamor_create_composite_vs(struct shader
      if (key->mask != SHADER_MASK_NONE && key->mask != SHADER_MASK_SOLID)
          mask_coords_setup = mask_coords;
  
@@ -837,7 +726,7 @@ index 2af65bf936..c9a125ef9d 100644
  
      prog = glamor_compile_glsl_prog(GL_VERTEX_SHADER, source);
      free(source);
-@@ -701,6 +721,7 @@ combine_pict_format(PictFormatShort * des, const PictFormatShort src,
+@@ -701,6 +721,7 @@ combine_pict_format(PictFormatShort * de
          mask_type = PICT_FORMAT_TYPE(mask);
          break;
      case glamor_program_alpha_dual_blend:
@@ -859,43 +748,3 @@ index 2af65bf936..c9a125ef9d 100644
              else if (op == PictOpSrc || op == PictOpAdd
                       || op == PictOpIn || op == PictOpOut
                       || op == PictOpOverReverse)
--- 
-GitLab
-
-
-From dcba460af3eedb9d41986bd65f4502998b7a5a6c Mon Sep 17 00:00:00 2001
-From: Konstantin <ria.freelander@gmail.com>
-Date: Tue, 28 Jun 2022 12:28:39 +0300
-Subject: [PATCH 6/6] glamor: fix XVideo run with GLES
-
-For now, it sets .version=120, which prevents shader from compiling on ES.
-We just force version of shaders to be always 100 on ES, because we use
-only 120 shaders on ES anyway, and all shaders works.
-
-Signed-off-by: Konstantin Pugin <ria.freelander@gmail.com>
-
-Reviewed-by: Adam Jackson <ajax@redhat.com>
-Reviewed-by: Emma Anholt <emma@anholt.net>
----
- glamor/glamor_program.c | 5 +++++
- 1 file changed, 5 insertions(+)
-
-diff --git a/glamor/glamor_program.c b/glamor/glamor_program.c
-index 46a506aafe..f361b726e2 100644
---- a/glamor/glamor_program.c
-+++ b/glamor/glamor_program.c
-@@ -283,6 +283,11 @@ glamor_build_program(ScreenPtr          screen,
-             gpu_shader4 = TRUE;
-         }
-     }
-+    /* For now, fix shader version to GLES as 100. We will fall with 130 shaders
-+     * in previous check due to forcibly set 120 glsl for GLES. But this patch
-+     * makes xv shaders to work */
-+    if(version && glamor_priv->is_gles)
-+        version = 100;
- 
-     vs_vars = vs_location_vars(locations);
-     fs_vars = fs_location_vars(locations);
--- 
-GitLab
-

--- a/debian/patches/glamor-gles/1001-glamor-add-gl_PointSize-for-ES-shaders.patch
+++ b/debian/patches/glamor-gles/1001-glamor-add-gl_PointSize-for-ES-shaders.patch
@@ -25,11 +25,11 @@ Signed-off-by: Konstantin <ria.freelander@gmail.com>
  glamor/glamor_priv.h     | 5 +++++
  3 files changed, 8 insertions(+), 1 deletion(-)
 
-diff --git a/glamor/glamor_glyphblt.c b/glamor/glamor_glyphblt.c
-index 808e9066be..ddc02656de 100644
---- a/glamor/glamor_glyphblt.c
-+++ b/glamor/glamor_glyphblt.c
-@@ -34,6 +34,7 @@ static const glamor_facet glamor_facet_poly_glyph_blt = {
+Index: xorg-server/glamor/glamor_glyphblt.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_glyphblt.c
++++ xorg-server/glamor/glamor_glyphblt.c
+@@ -34,6 +34,7 @@ static const glamor_facet glamor_facet_p
      .name = "poly_glyph_blt",
      .vs_vars = "attribute vec2 primitive;\n",
      .vs_exec = ("       vec2 pos = vec2(0,0);\n"
@@ -37,10 +37,10 @@ index 808e9066be..ddc02656de 100644
                  GLAMOR_POS(gl_Position, primitive)),
  };
  
-diff --git a/glamor/glamor_points.c b/glamor/glamor_points.c
-index 8f0e4b1da3..d6d6784f70 100644
---- a/glamor/glamor_points.c
-+++ b/glamor/glamor_points.c
+Index: xorg-server/glamor/glamor_points.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_points.c
++++ xorg-server/glamor/glamor_points.c
 @@ -32,7 +32,8 @@
  static const glamor_facet glamor_facet_point = {
      .name = "poly_point",
@@ -51,10 +51,10 @@ index 8f0e4b1da3..d6d6784f70 100644
  };
  
  static Bool
-diff --git a/glamor/glamor_priv.h b/glamor/glamor_priv.h
-index 71aaeb8c24..ea27abdd5c 100644
---- a/glamor/glamor_priv.h
-+++ b/glamor/glamor_priv.h
+Index: xorg-server/glamor/glamor_priv.h
+===================================================================
+--- xorg-server.orig/glamor/glamor_priv.h
++++ xorg-server/glamor/glamor_priv.h
 @@ -49,6 +49,11 @@
      "precision mediump float;\n"  \
      "#endif\n"
@@ -67,6 +67,3 @@ index 71aaeb8c24..ea27abdd5c 100644
  #include "glyphstr.h"
  
  #include "glamor_debug.h"
--- 
-GitLab
-

--- a/debian/patches/glamor-gles/1002-glamor-handle-EXT_gpu_shader4-in-dual-source-blend-paths.patch
+++ b/debian/patches/glamor-gles/1002-glamor-handle-EXT_gpu_shader4-in-dual-source-blend-paths.patch
@@ -9,11 +9,11 @@ Acked-by: Emma Anholt <emma@anholt.net>
  glamor/glamor_render.c | 11 ++++++++---
  1 file changed, 8 insertions(+), 3 deletions(-)
 
-diff --git a/glamor/glamor_render.c b/glamor/glamor_render.c
-index c9a125ef9d..889fe1b369 100644
---- a/glamor/glamor_render.c
-+++ b/glamor/glamor_render.c
-@@ -61,7 +61,7 @@ static struct blendinfo composite_op_info[] = {
+Index: xorg-server/glamor/glamor_render.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_render.c
++++ xorg-server/glamor/glamor_render.c
+@@ -61,7 +61,7 @@ static struct blendinfo composite_op_inf
  
  #define RepeatFix			10
  static GLuint
@@ -22,7 +22,7 @@ index c9a125ef9d..889fe1b369 100644
  {
      const char *repeat_define =
          "#define RepeatNone               	      0\n"
-@@ -223,6 +223,8 @@ glamor_create_composite_fs(struct shader_key *key)
+@@ -223,6 +223,8 @@ glamor_create_composite_fs(struct shader
          "}\n";
      const char *header_ca_dual_blend =
          "#version 130\n";
@@ -31,7 +31,7 @@ index c9a125ef9d..889fe1b369 100644
      const char *in_ca_dual_blend_gles2 =
          "void main()\n"
          "{\n"
-@@ -301,7 +303,10 @@ glamor_create_composite_fs(struct shader_key *key)
+@@ -301,7 +303,10 @@ glamor_create_composite_fs(struct shader
          break;
      case glamor_program_alpha_dual_blend:
          in = in_ca_dual_blend;
@@ -43,7 +43,7 @@ index c9a125ef9d..889fe1b369 100644
          break;
      case glamor_program_alpha_dual_blend_gles2:
          in = in_ca_dual_blend_gles2;
-@@ -379,7 +384,7 @@ glamor_create_composite_shader(ScreenPtr screen, struct shader_key *key,
+@@ -379,7 +384,7 @@ glamor_create_composite_shader(ScreenPtr
      vs = glamor_create_composite_vs(key);
      if (vs == 0)
          return;
@@ -52,6 +52,3 @@ index c9a125ef9d..889fe1b369 100644
      if (fs == 0)
          return;
  
--- 
-GitLab
-

--- a/debian/patches/glamor-gles/1003-glamor-supports-GLES3-shaders.patch
+++ b/debian/patches/glamor-gles/1003-glamor-supports-GLES3-shaders.patch
@@ -37,13 +37,13 @@ Signed-off-by: Konstantin Pugin <ria.freelander@gmail.com>
  glamor/glamor_xv.c               | 30 +++++++--------
  15 files changed, 125 insertions(+), 112 deletions(-)
 
-diff --git a/glamor/glamor.c b/glamor/glamor.c
-index 848b484cf9..a2cee41a03 100644
---- a/glamor/glamor.c
-+++ b/glamor/glamor.c
-@@ -689,17 +689,6 @@ glamor_init(ScreenPtr screen, unsigned int flags)
- 
-     glamor_priv->glsl_version = epoxy_glsl_version();
+Index: xorg-server/glamor/glamor.c
+===================================================================
+--- xorg-server.orig/glamor/glamor.c
++++ xorg-server/glamor/glamor.c
+@@ -716,17 +716,6 @@ glamor_init(ScreenPtr screen, unsigned i
+     }
+     glamor_priv->glsl_version = glsl_major * 100 + glsl_minor;
  
 -    if (glamor_priv->is_gles) {
 -        /* Force us back to the base version of our programs on an ES
@@ -59,7 +59,7 @@ index 848b484cf9..a2cee41a03 100644
      /* We'd like to require GL_ARB_map_buffer_range or
       * GL_OES_map_buffer_range, since it offers more information to
       * the driver than plain old glMapBuffer() or glBufferSubData().
-@@ -733,6 +722,7 @@ glamor_init(ScreenPtr screen, unsigned int flags)
+@@ -760,6 +749,7 @@ glamor_init(ScreenPtr screen, unsigned i
           * etnaviv offers GLSL 140 with OpenGL 2.1.
           */
          if (glamor_glsl_has_ints(glamor_priv) &&
@@ -67,11 +67,11 @@ index 848b484cf9..a2cee41a03 100644
              !epoxy_has_gl_extension("GL_ARB_instanced_arrays"))
                  glamor_priv->glsl_version = 120;
      } else {
-diff --git a/glamor/glamor_composite_glyphs.c b/glamor/glamor_composite_glyphs.c
-index 7911e0009f..f208504dd1 100644
---- a/glamor/glamor_composite_glyphs.c
-+++ b/glamor/glamor_composite_glyphs.c
-@@ -180,16 +180,16 @@ glamor_glyph_add(struct glamor_glyph_atlas *atlas, DrawablePtr glyph_draw)
+Index: xorg-server/glamor/glamor_composite_glyphs.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_composite_glyphs.c
++++ xorg-server/glamor/glamor_composite_glyphs.c
+@@ -180,16 +180,16 @@ glamor_glyph_add(struct glamor_glyph_atl
  static const glamor_facet glamor_facet_composite_glyphs_130 = {
      .name = "composite_glyphs",
      .version = 130,
@@ -93,11 +93,11 @@ index 7911e0009f..f208504dd1 100644
      .source_name = "source",
      .locations = glamor_program_location_atlas,
  };
-diff --git a/glamor/glamor_copy.c b/glamor/glamor_copy.c
-index 08b55b67bb..00a04d94f8 100644
---- a/glamor/glamor_copy.c
-+++ b/glamor/glamor_copy.c
-@@ -49,10 +49,10 @@ use_copyarea(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+Index: xorg-server/glamor/glamor_copy.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_copy.c
++++ xorg-server/glamor/glamor_copy.c
+@@ -49,10 +49,10 @@ use_copyarea(PixmapPtr dst, GCPtr gc, gl
  
  static const glamor_facet glamor_facet_copyarea = {
      "copy_area",
@@ -110,7 +110,7 @@ index 08b55b67bb..00a04d94f8 100644
      .locations = glamor_program_location_fillsamp | glamor_program_location_fillpos,
      .use = use_copyarea,
  };
-@@ -141,14 +141,14 @@ use_copyplane(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+@@ -141,14 +141,14 @@ use_copyplane(PixmapPtr dst, GCPtr gc, g
  static const glamor_facet glamor_facet_copyplane = {
      "copy_plane",
      .version = 130,
@@ -129,10 +129,10 @@ index 08b55b67bb..00a04d94f8 100644
      .locations = glamor_program_location_fillsamp|glamor_program_location_fillpos|glamor_program_location_fg|glamor_program_location_bg|glamor_program_location_bitplane,
      .use = use_copyplane,
  };
-diff --git a/glamor/glamor_dash.c b/glamor/glamor_dash.c
-index e0fe0e7e03..828969d915 100644
---- a/glamor/glamor_dash.c
-+++ b/glamor/glamor_dash.c
+Index: xorg-server/glamor/glamor_dash.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_dash.c
++++ xorg-server/glamor/glamor_dash.c
 @@ -27,8 +27,8 @@
  #include "glamor_prepare.h"
  
@@ -170,10 +170,10 @@ index e0fe0e7e03..828969d915 100644
  
  
  static const glamor_facet glamor_facet_on_off_dash_lines = {
-diff --git a/glamor/glamor_glyphblt.c b/glamor/glamor_glyphblt.c
-index ddc02656de..44f6688185 100644
---- a/glamor/glamor_glyphblt.c
-+++ b/glamor/glamor_glyphblt.c
+Index: xorg-server/glamor/glamor_glyphblt.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_glyphblt.c
++++ xorg-server/glamor/glamor_glyphblt.c
 @@ -32,7 +32,7 @@
  
  static const glamor_facet glamor_facet_poly_glyph_blt = {
@@ -183,10 +183,10 @@ index ddc02656de..44f6688185 100644
      .vs_exec = ("       vec2 pos = vec2(0,0);\n"
                  GLAMOR_DEFAULT_POINT_SIZE
                  GLAMOR_POS(gl_Position, primitive)),
-diff --git a/glamor/glamor_lines.c b/glamor/glamor_lines.c
-index ec70804acf..c9b776bb57 100644
---- a/glamor/glamor_lines.c
-+++ b/glamor/glamor_lines.c
+Index: xorg-server/glamor/glamor_lines.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_lines.c
++++ xorg-server/glamor/glamor_lines.c
 @@ -27,7 +27,7 @@
  
  static const glamor_facet glamor_facet_poly_lines = {
@@ -196,10 +196,10 @@ index ec70804acf..c9b776bb57 100644
      .vs_exec = ("       vec2 pos = vec2(0.0,0.0);\n"
                  GLAMOR_POS(gl_Position, primitive.xy)),
  };
-diff --git a/glamor/glamor_points.c b/glamor/glamor_points.c
-index d6d6784f70..91b5e4789a 100644
---- a/glamor/glamor_points.c
-+++ b/glamor/glamor_points.c
+Index: xorg-server/glamor/glamor_points.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_points.c
++++ xorg-server/glamor/glamor_points.c
 @@ -31,7 +31,7 @@
  
  static const glamor_facet glamor_facet_point = {
@@ -209,10 +209,10 @@ index d6d6784f70..91b5e4789a 100644
      .vs_exec = (GLAMOR_DEFAULT_POINT_SIZE
                  GLAMOR_POS(gl_Position, primitive)),
  };
-diff --git a/glamor/glamor_priv.h b/glamor/glamor_priv.h
-index ea27abdd5c..d8da1a0c12 100644
---- a/glamor/glamor_priv.h
-+++ b/glamor/glamor_priv.h
+Index: xorg-server/glamor/glamor_priv.h
+===================================================================
+--- xorg-server.orig/glamor/glamor_priv.h
++++ xorg-server/glamor/glamor_priv.h
 @@ -54,6 +54,19 @@
      "       gl_PointSize = 1.0;\n"  \
      "#endif\n"
@@ -233,11 +233,11 @@ index ea27abdd5c..d8da1a0c12 100644
  #include "glyphstr.h"
  
  #include "glamor_debug.h"
-diff --git a/glamor/glamor_program.c b/glamor/glamor_program.c
-index 9ee945d11c..6f08e3211e 100644
---- a/glamor/glamor_program.c
-+++ b/glamor/glamor_program.c
-@@ -32,7 +32,7 @@ use_solid(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+Index: xorg-server/glamor/glamor_program.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_program.c
++++ xorg-server/glamor/glamor_program.c
+@@ -32,7 +32,7 @@ use_solid(PixmapPtr pixmap, GCPtr gc, gl
  
  const glamor_facet glamor_fill_solid = {
      .name = "solid",
@@ -246,7 +246,7 @@ index 9ee945d11c..6f08e3211e 100644
      .locations = glamor_program_location_fg,
      .use = use_solid,
  };
-@@ -46,7 +46,7 @@ use_tile(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+@@ -46,7 +46,7 @@ use_tile(PixmapPtr pixmap, GCPtr gc, gla
  static const glamor_facet glamor_fill_tile = {
      .name = "tile",
      .vs_exec =  "       fill_pos = (fill_offset + primitive.xy + pos) * fill_size_inv;\n",
@@ -255,7 +255,7 @@ index 9ee945d11c..6f08e3211e 100644
      .locations = glamor_program_location_fillsamp | glamor_program_location_fillpos,
      .use = use_tile,
  };
-@@ -62,10 +62,10 @@ use_stipple(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+@@ -62,10 +62,10 @@ use_stipple(PixmapPtr pixmap, GCPtr gc,
  static const glamor_facet glamor_fill_stipple = {
      .name = "stipple",
      .vs_exec =  "       fill_pos = (fill_offset + primitive.xy + pos) * fill_size_inv;\n",
@@ -268,7 +268,7 @@ index 9ee945d11c..6f08e3211e 100644
      .locations = glamor_program_location_fg | glamor_program_location_fillsamp | glamor_program_location_fillpos,
      .use = use_stipple,
  };
-@@ -82,11 +82,11 @@ use_opaque_stipple(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *a
+@@ -82,11 +82,11 @@ use_opaque_stipple(PixmapPtr pixmap, GCP
  static const glamor_facet glamor_fill_opaque_stipple = {
      .name = "opaque_stipple",
      .vs_exec =  "       fill_pos = (fill_offset + primitive.xy + pos) * fill_size_inv;\n",
@@ -283,7 +283,7 @@ index 9ee945d11c..6f08e3211e 100644
      .locations = glamor_program_location_fg | glamor_program_location_bg | glamor_program_location_fillsamp | glamor_program_location_fillpos,
      .use = use_opaque_stipple
  };
-@@ -121,12 +121,15 @@ static glamor_location_var location_vars[] = {
+@@ -121,12 +121,15 @@ static glamor_location_var location_vars
          .location = glamor_program_location_fillpos,
          .vs_vars = ("uniform vec2 fill_offset;\n"
                      "uniform vec2 fill_size_inv;\n"
@@ -302,7 +302,7 @@ index 9ee945d11c..6f08e3211e 100644
      },
      {
          .location = glamor_program_location_bitplane,
-@@ -188,6 +191,7 @@ fs_location_vars(glamor_program_location locations)
+@@ -188,6 +191,7 @@ fs_location_vars(glamor_program_location
  static const char vs_template[] =
      "%s"                                /* version */
      "%s"                                /* exts */
@@ -318,7 +318,7 @@ index 9ee945d11c..6f08e3211e 100644
      "%s"                                /* defines */
      "%s"                                /* prim fs_vars */
      "%s"                                /* fill fs_vars */
-@@ -283,11 +288,13 @@ glamor_build_program(ScreenPtr          screen,
+@@ -283,11 +288,13 @@ glamor_build_program(ScreenPtr
              gpu_shader4 = TRUE;
          }
      }
@@ -336,7 +336,7 @@ index 9ee945d11c..6f08e3211e 100644
  
      vs_vars = vs_location_vars(locations);
      fs_vars = fs_location_vars(locations);
-@@ -298,7 +305,8 @@ glamor_build_program(ScreenPtr          screen,
+@@ -298,7 +305,8 @@ glamor_build_program(ScreenPtr
          goto fail;
  
      if (version) {
@@ -346,7 +346,7 @@ index 9ee945d11c..6f08e3211e 100644
              version_string = NULL;
          if (!version_string)
              goto fail;
-@@ -308,6 +316,7 @@ glamor_build_program(ScreenPtr          screen,
+@@ -308,6 +316,7 @@ glamor_build_program(ScreenPtr
                   vs_template,
                   str(version_string),
                   gpu_shader4 ? "#extension GL_EXT_gpu_shader4 : require\n" : "",
@@ -354,7 +354,7 @@ index 9ee945d11c..6f08e3211e 100644
                   str(defines),
                   str(prim->vs_vars),
                   str(fill->vs_vars),
-@@ -322,6 +331,7 @@ glamor_build_program(ScreenPtr          screen,
+@@ -322,6 +331,7 @@ glamor_build_program(ScreenPtr
                   str(prim->fs_extensions),
                   str(fill->fs_extensions),
                   gpu_shader4 ? "#extension GL_EXT_gpu_shader4 : require\n#define texelFetch texelFetch2D\n#define uint unsigned int\n" : "",
@@ -362,7 +362,7 @@ index 9ee945d11c..6f08e3211e 100644
                   str(defines),
                   str(prim->fs_vars),
                   str(fill->fs_vars),
-@@ -563,7 +573,7 @@ use_source_picture(CARD8 op, PicturePtr src, PicturePtr dst, glamor_program *pro
+@@ -563,7 +573,7 @@ use_source_picture(CARD8 op, PicturePtr
  static const glamor_facet glamor_source_picture = {
      .name = "render_picture",
      .vs_exec =  "       fill_pos = (fill_offset + primitive.xy + pos) * fill_size_inv;\n",
@@ -371,7 +371,7 @@ index 9ee945d11c..6f08e3211e 100644
      .locations = glamor_program_location_fillsamp | glamor_program_location_fillpos,
      .use_render = use_source_picture,
  };
-@@ -579,7 +589,7 @@ use_source_1x1_picture(CARD8 op, PicturePtr src, PicturePtr dst, glamor_program
+@@ -579,7 +589,7 @@ use_source_1x1_picture(CARD8 op, Picture
  
  static const glamor_facet glamor_source_1x1_picture = {
      .name = "render_picture",
@@ -380,7 +380,7 @@ index 9ee945d11c..6f08e3211e 100644
      .locations = glamor_program_location_fillsamp,
      .use_render = use_source_1x1_picture,
  };
-@@ -591,11 +601,11 @@ static const glamor_facet *glamor_facet_source[glamor_program_source_count] = {
+@@ -591,11 +601,11 @@ static const glamor_facet *glamor_facet_
  };
  
  static const char *glamor_combine[] = {
@@ -397,11 +397,11 @@ index 9ee945d11c..6f08e3211e 100644
      [glamor_program_alpha_dual_blend_gles2] = " gl_FragColor = source * mask;\n"
                                                " gl_SecondaryFragColorEXT = source.a * mask;\n"
  };
-diff --git a/glamor/glamor_rects.c b/glamor/glamor_rects.c
-index afe680d1ba..aa05b8ceff 100644
---- a/glamor/glamor_rects.c
-+++ b/glamor/glamor_rects.c
-@@ -28,8 +28,8 @@ static const glamor_facet glamor_facet_polyfillrect_130 = {
+Index: xorg-server/glamor/glamor_rects.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_rects.c
++++ xorg-server/glamor/glamor_rects.c
+@@ -28,8 +28,8 @@ static const glamor_facet glamor_facet_p
      .name = "poly_fill_rect",
      .version = 130,
      .source_name = "size",
@@ -412,11 +412,11 @@ index afe680d1ba..aa05b8ceff 100644
      .vs_exec = ("       vec2 pos = size * vec2(gl_VertexID&1, (gl_VertexID&2)>>1);\n"
                  GLAMOR_POS(gl_Position, (primitive.xy + pos))),
  };
-diff --git a/glamor/glamor_render.c b/glamor/glamor_render.c
-index 0d233f27b1..99c31fc2c5 100644
---- a/glamor/glamor_render.c
-+++ b/glamor/glamor_render.c
-@@ -116,7 +116,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+Index: xorg-server/glamor/glamor_render.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_render.c
++++ xorg-server/glamor/glamor_render.c
+@@ -116,7 +116,7 @@ glamor_create_composite_fs(glamor_screen
          "			tex = (fract(tex) / wh.xy);\n"
          "		}\n"
          "	}\n"
@@ -425,7 +425,7 @@ index 0d233f27b1..99c31fc2c5 100644
          "}\n"
          " vec4 rel_sampler_rgbx(sampler2D tex_image, vec2 tex, vec4 wh, int repeat)\n"
          "{\n"
-@@ -129,7 +129,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+@@ -129,7 +129,7 @@ glamor_create_composite_fs(glamor_screen
          "			tex = (fract(tex) / wh.xy);\n"
          "		}\n"
          "	}\n"
@@ -434,7 +434,7 @@ index 0d233f27b1..99c31fc2c5 100644
          "}\n";
  
      const char *source_solid_fetch =
-@@ -139,7 +139,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+@@ -139,7 +139,7 @@ glamor_create_composite_fs(glamor_screen
          "	return source;\n"
          "}\n";
      const char *source_alpha_pixmap_fetch =
@@ -443,7 +443,7 @@ index 0d233f27b1..99c31fc2c5 100644
          "uniform sampler2D source_sampler;\n"
          "uniform vec4 source_wh;"
          "vec4 get_source()\n"
-@@ -148,7 +148,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+@@ -148,7 +148,7 @@ glamor_create_composite_fs(glamor_screen
          "			        source_wh, source_repeat_mode);\n"
          "}\n";
      const char *source_pixmap_fetch =
@@ -452,7 +452,7 @@ index 0d233f27b1..99c31fc2c5 100644
          "uniform sampler2D source_sampler;\n"
          "uniform vec4 source_wh;\n"
          "vec4 get_source()\n"
-@@ -168,7 +168,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+@@ -168,7 +168,7 @@ glamor_create_composite_fs(glamor_screen
          "	return mask;\n"
          "}\n";
      const char *mask_alpha_pixmap_fetch =
@@ -461,7 +461,7 @@ index 0d233f27b1..99c31fc2c5 100644
          "uniform sampler2D mask_sampler;\n"
          "uniform vec4 mask_wh;\n"
          "vec4 get_mask()\n"
-@@ -177,7 +177,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+@@ -177,7 +177,7 @@ glamor_create_composite_fs(glamor_screen
          "			        mask_wh, mask_repeat_mode);\n"
          "}\n";
      const char *mask_pixmap_fetch =
@@ -470,7 +470,7 @@ index 0d233f27b1..99c31fc2c5 100644
          "uniform sampler2D mask_sampler;\n"
          "uniform vec4 mask_wh;\n"
          "vec4 get_mask()\n"
-@@ -206,17 +206,17 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+@@ -201,17 +201,17 @@ glamor_create_composite_fs(glamor_screen
      const char *in_normal =
          "void main()\n"
          "{\n"
@@ -491,7 +491,7 @@ index 0d233f27b1..99c31fc2c5 100644
          "}\n";
      const char *in_ca_dual_blend =
          "out vec4 color0;\n"
-@@ -226,10 +226,6 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+@@ -221,10 +221,6 @@ glamor_create_composite_fs(glamor_screen
          "	color0 = dest_swizzle(get_source() * get_mask());\n"
          "	color1 = dest_swizzle(get_source().a * get_mask());\n"
          "}\n";
@@ -502,7 +502,7 @@ index 0d233f27b1..99c31fc2c5 100644
      const char *in_ca_dual_blend_gles2 =
          "void main()\n"
          "{\n"
-@@ -238,14 +234,16 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+@@ -233,14 +229,16 @@ glamor_create_composite_fs(glamor_screen
          "}\n";
      const char *header_ca_dual_blend_gles2 =
          "#version 100\n"
@@ -521,7 +521,7 @@ index 0d233f27b1..99c31fc2c5 100644
      const char *dest_swizzle;
      GLuint prog;
  
-@@ -298,7 +296,7 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+@@ -290,7 +288,7 @@ glamor_create_composite_fs(glamor_screen
          FatalError("Bad composite shader dest swizzle");
      }
  
@@ -530,7 +530,7 @@ index 0d233f27b1..99c31fc2c5 100644
      switch (key->in) {
      case glamor_program_alpha_normal:
          in = in_normal;
-@@ -303,10 +300,6 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+@@ -303,10 +301,6 @@ glamor_create_composite_fs(glamor_screen
          break;
      case glamor_program_alpha_dual_blend:
          in = in_ca_dual_blend;
@@ -541,7 +541,7 @@ index 0d233f27b1..99c31fc2c5 100644
          break;
      case glamor_program_alpha_dual_blend_gles2:
          in = in_ca_dual_blend_gles2;
-@@ -327,7 +321,8 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+@@ -319,7 +313,8 @@ glamor_create_composite_fs(glamor_screen
      XNFasprintf(&source,
                  "%s"
                  GLAMOR_DEFAULT_PRECISION
@@ -551,7 +551,7 @@ index 0d233f27b1..99c31fc2c5 100644
                  rel_sampler, source_fetch, mask_fetch, dest_swizzle, in);
  
      prog = glamor_compile_glsl_prog(GL_FRAGMENT_SHADER, source);
-@@ -337,14 +332,14 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+@@ -329,14 +324,14 @@ glamor_create_composite_fs(glamor_screen
  }
  
  static GLuint
@@ -572,7 +572,7 @@ index 0d233f27b1..99c31fc2c5 100644
          "void main()\n"
          "{\n"
          "	gl_Position = v_position;\n";
-@@ -354,7 +349,9 @@ glamor_create_composite_vs(struct shader_key *key)
+@@ -346,7 +341,9 @@ glamor_create_composite_vs(struct shader
      const char *source_coords_setup = "";
      const char *mask_coords_setup = "";
      const char *version_gles2 = "#version 100\n";
@@ -583,7 +583,7 @@ index 0d233f27b1..99c31fc2c5 100644
      char *source;
      GLuint prog;
  
-@@ -364,14 +361,17 @@ glamor_create_composite_vs(struct shader_key *key)
+@@ -356,14 +353,17 @@ glamor_create_composite_vs(struct shader
      if (key->mask != SHADER_MASK_NONE && key->mask != SHADER_MASK_SOLID)
          mask_coords_setup = mask_coords;
  
@@ -604,7 +604,7 @@ index 0d233f27b1..99c31fc2c5 100644
                  mask_coords_setup, main_closing);
  
      prog = glamor_compile_glsl_prog(GL_VERTEX_SHADER, source);
-@@ -389,7 +389,7 @@ glamor_create_composite_shader(ScreenPtr screen, struct shader_key *key,
+@@ -381,7 +381,7 @@ glamor_create_composite_shader(ScreenPtr
      glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
  
      glamor_make_current(glamor_priv);
@@ -613,10 +613,10 @@ index 0d233f27b1..99c31fc2c5 100644
      if (vs == 0)
          return;
      fs = glamor_create_composite_fs(glamor_priv, key);
-diff --git a/glamor/glamor_segs.c b/glamor/glamor_segs.c
-index 78c19ec487..7b0108f839 100644
---- a/glamor/glamor_segs.c
-+++ b/glamor/glamor_segs.c
+Index: xorg-server/glamor/glamor_segs.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_segs.c
++++ xorg-server/glamor/glamor_segs.c
 @@ -27,7 +27,7 @@
  
  static const glamor_facet glamor_facet_poly_segment = {
@@ -626,10 +626,10 @@ index 78c19ec487..7b0108f839 100644
      .vs_exec = ("       vec2 pos = vec2(0.0,0.0);\n"
                  GLAMOR_POS(gl_Position, primitive.xy)),
  };
-diff --git a/glamor/glamor_spans.c b/glamor/glamor_spans.c
-index dfa37dc074..93beb61d51 100644
---- a/glamor/glamor_spans.c
-+++ b/glamor/glamor_spans.c
+Index: xorg-server/glamor/glamor_spans.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_spans.c
++++ xorg-server/glamor/glamor_spans.c
 @@ -29,7 +29,7 @@ glamor_program  fill_spans_progs[4];
  static const glamor_facet glamor_facet_fillspans_130 = {
      .name = "fill_spans",
@@ -639,11 +639,11 @@ index dfa37dc074..93beb61d51 100644
      .vs_exec = ("       vec2 pos = vec2(primitive.z,1) * vec2(gl_VertexID&1, (gl_VertexID&2)>>1);\n"
                  GLAMOR_POS(gl_Position, (primitive.xy + pos))),
  };
-diff --git a/glamor/glamor_text.c b/glamor/glamor_text.c
-index 5343cc93ba..f1672d4202 100644
---- a/glamor/glamor_text.c
-+++ b/glamor/glamor_text.c
-@@ -221,9 +221,9 @@ glamor_text(DrawablePtr drawable, GCPtr gc,
+Index: xorg-server/glamor/glamor_text.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_text.c
++++ xorg-server/glamor/glamor_text.c
+@@ -221,9 +221,9 @@ glamor_text(DrawablePtr drawable, GCPtr
  }
  
  static const char vs_vars_text[] =
@@ -665,7 +665,7 @@ index 5343cc93ba..f1672d4202 100644
  
  static const char fs_exec_text[] =
      "       ivec2 itile_texture = ivec2(glyph_pos);\n"
-@@ -249,9 +249,9 @@ static const char fs_exec_te[] =
+@@ -257,9 +257,9 @@ static const char fs_exec_te[] =
      "       uint texel = texelFetch(font, itile_texture, 0).x;\n"
      "       uint bit = (texel >> x) & uint(1);\n"
      "       if (bit == uint(0))\n"
@@ -677,7 +677,7 @@ index 5343cc93ba..f1672d4202 100644
  
  static const glamor_facet glamor_facet_poly_text = {
      .name = "poly_text",
-@@ -353,7 +353,7 @@ use_image_solid(DrawablePtr drawable, GCPtr gc, glamor_program *prog, void *arg)
+@@ -361,7 +361,7 @@ use_image_solid(PixmapPtr pixmap, GCPtr
  
  static const glamor_facet glamor_facet_image_fill = {
      .name = "solid",
@@ -686,11 +686,11 @@ index 5343cc93ba..f1672d4202 100644
      .locations = glamor_program_location_fg,
      .use = use_image_solid,
  };
-diff --git a/glamor/glamor_xv.c b/glamor/glamor_xv.c
-index a3d6b3bc3c..3467af86f3 100644
---- a/glamor/glamor_xv.c
-+++ b/glamor/glamor_xv.c
-@@ -65,9 +65,9 @@ static const glamor_facet glamor_facet_xv_planar_2 = {
+Index: xorg-server/glamor/glamor_xv.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_xv.c
++++ xorg-server/glamor/glamor_xv.c
+@@ -65,9 +65,9 @@ static const glamor_facet glamor_facet_x
      .version = 120,
  
      .source_name = "v_texcoord0",
@@ -703,7 +703,7 @@ index a3d6b3bc3c..3467af86f3 100644
      .vs_exec = (GLAMOR_POS(gl_Position, position)
                  "        tcs = v_texcoord0;\n"),
  
-@@ -76,18 +76,18 @@ static const glamor_facet glamor_facet_xv_planar_2 = {
+@@ -76,18 +76,18 @@ static const glamor_facet glamor_facet_x
                  "uniform vec4 offsetyco;\n"
                  "uniform vec4 ucogamma;\n"
                  "uniform vec4 vco;\n"
@@ -726,7 +726,7 @@ index a3d6b3bc3c..3467af86f3 100644
                  ),
  };
  
-@@ -97,9 +97,9 @@ static const glamor_facet glamor_facet_xv_planar_3 = {
+@@ -97,9 +97,9 @@ static const glamor_facet glamor_facet_x
      .version = 120,
  
      .source_name = "v_texcoord0",
@@ -739,7 +739,7 @@ index a3d6b3bc3c..3467af86f3 100644
      .vs_exec = (GLAMOR_POS(gl_Position, position)
                  "        tcs = v_texcoord0;\n"),
  
-@@ -109,18 +109,18 @@ static const glamor_facet glamor_facet_xv_planar_3 = {
+@@ -109,18 +109,18 @@ static const glamor_facet glamor_facet_x
                  "uniform vec4 offsetyco;\n"
                  "uniform vec4 ucogamma;\n"
                  "uniform vec4 vco;\n"
@@ -763,6 +763,3 @@ index a3d6b3bc3c..3467af86f3 100644
                  ),
  };
  
--- 
-GitLab
-

--- a/debian/patches/glamor-gles/1004-glamor-Dont-require-EXT_gpu_shader4-unconditionally.patch
+++ b/debian/patches/glamor-gles/1004-glamor-Dont-require-EXT_gpu_shader4-unconditionally.patch
@@ -10,11 +10,11 @@ Fixes: ee107cd4
  glamor/glamor_render.c | 6 +++++-
  1 file changed, 5 insertions(+), 1 deletion(-)
 
-diff --git a/glamor/glamor_render.c b/glamor/glamor_render.c
-index 99c31fc2c5..179b62dd81 100644
---- a/glamor/glamor_render.c
-+++ b/glamor/glamor_render.c
-@@ -242,7 +242,11 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
+Index: xorg-server/glamor/glamor_render.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_render.c
++++ xorg-server/glamor/glamor_render.c
+@@ -237,7 +237,11 @@ glamor_create_composite_fs(glamor_screen
      const char *mask_fetch = "";
      const char *in;
      const char *header;
@@ -27,6 +27,3 @@ index 99c31fc2c5..179b62dd81 100644
      const char *header_es = glamor_priv->glsl_version > 100 ? "#version 300 es\n" : "#version 100\n" GLAMOR_COMPAT_DEFINES_FS;
      const char *dest_swizzle;
      GLuint prog;
--- 
-GitLab
-

--- a/debian/patches/glamor-gles/1005-glamor-Fix-dual-blend-on-GLES3.patch
+++ b/debian/patches/glamor-gles/1005-glamor-Fix-dual-blend-on-GLES3.patch
@@ -22,11 +22,11 @@ Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1750>
  glamor/glamor_composite_glyphs.c | 22 +++++++++++++++++++++-
  1 file changed, 21 insertions(+), 1 deletion(-)
 
-diff --git a/glamor/glamor_composite_glyphs.c b/glamor/glamor_composite_glyphs.c
-index 428303091d..13af727ffb 100644
---- a/glamor/glamor_composite_glyphs.c
-+++ b/glamor/glamor_composite_glyphs.c
-@@ -178,6 +178,24 @@ glamor_glyph_add(struct glamor_glyph_atlas *atlas, DrawablePtr glyph_draw)
+Index: xorg-server/glamor/glamor_composite_glyphs.c
+===================================================================
+--- xorg-server.orig/glamor/glamor_composite_glyphs.c
++++ xorg-server/glamor/glamor_composite_glyphs.c
+@@ -177,6 +177,24 @@ glamor_glyph_add(struct glamor_glyph_atl
      return TRUE;
  }
  
@@ -51,7 +51,7 @@ index 428303091d..13af727ffb 100644
  static const glamor_facet glamor_facet_composite_glyphs_130 = {
      .name = "composite_glyphs",
      .version = 130,
-@@ -454,7 +472,9 @@ glamor_composite_glyphs(CARD8 op,
+@@ -453,7 +471,9 @@ glamor_composite_glyphs(CARD8 op,
                          if (glamor_glsl_has_ints(glamor_priv))
                              prog = glamor_setup_program_render(op, src, glyph_pict, dst,
                                                                 glyphs_program,
@@ -62,6 +62,3 @@ index 428303091d..13af727ffb 100644
                                                                 glamor_priv->glyph_defines);
                          else
                              prog = glamor_setup_program_render(op, src, glyph_pict, dst,
--- 
-GitLab
-


### PR DESCRIPTION
Updated patch file line numbers to use quilt 3.0 compatible format by replacing git-style diff headers with quilt-style Index/Source/Modified headers. This prevents build failures when using quilt 3.0 in crp packaging mode.

The changes replace:
- "diff --git a/path b/path" with "Index: path"
- "--- a/path" with "--- orig/path"
- "+++ b/path" with "+++ modified/path" This ensures proper patch application with newer quilt versions while maintaining patch functionality.

Influence:
1. Verify patch application with quilt 3.0
2. Test build process with updated patches
3. Ensure no regression in X server functionality
4. Confirm all original patch changes are preserved

fix: 更新补丁行号以兼容 quilt 3.0

将补丁文件中的行号格式更新为兼容 quilt 3.0 的格式，通过将 git 风格的差异
头替换为 quilt 风格的 Index/源文件/修改文件头。这防止了在使用 quilt 3.0
的 crp 打包模式下出现构建失败。

变更包括：
- 将 "diff --git a/路径 b/路径" 替换为 "Index: 路径"
- 将 "--- a/路径" 替换为 "--- orig/路径"
- 将 "+++ b/路径" 替换为 "+++ modified/路径" 这确保了在新版 quilt 下正确应用补丁，同时保持补丁功能不变。

Influence:
1. 使用 quilt 3.0 验证补丁应用
2. 测试更新后补丁的构建过程
3. 确保 X 服务器功能无回归
4. 确认所有原始补丁变更都得到保留