### PR TITLE
fix: correct parameters for UaceCensorImage call

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xorg-server (2:21.1.10-1deepin13) unstable; urgency=medium
+
+  * fix: correct parameters for UaceCensorImage call
+
+ -- liuheng <liuhenga@uniontech.com>  Tue, 11 Nov 2025 15:08:28 +0800
+
 xorg-server (2:21.1.10-1deepin12) unstable; urgency=medium
 
   * fix: update patch line numbers for quilt 3.0 compatibility

--- a/debian/patches/0001-feat-implement-screenshot-protection-for-secure-wind.patch
+++ b/debian/patches/0001-feat-implement-screenshot-protection-for-secure-wind.patch
@@ -463,7 +463,7 @@ Index: xorg-server/dix/dispatch.c
  
      if (pDraw->type == DRAWABLE_WINDOW) {
          WindowPtr pWin = (WindowPtr) pDraw;
-@@ -2283,16 +2613,23 @@ DoGetImage(ClientPtr client, int format,
+@@ -2283,16 +2613,21 @@ DoGetImage(ClientPtr client, int format,
                                           width,
                                           nlines,
                                           format, planemask, (void *) pBuf);
@@ -480,10 +480,8 @@ Index: xorg-server/dix/dispatch.c
                            BitsPerPixel(pDraw->depth), ClientOrder(client));
 -
 +            if (!isWindowManager) {
-+                int depth = format == ZPixmap ? pDraw->depth : 1;
-+                int bitsPerPixel = format == ZPixmap ? pDraw->bitsPerPixel : 1;
-+                PixmapPtr pPix = GetScratchPixmapHeader(pDraw->pScreen, width, nlines, depth, bitsPerPixel, widthBytesLine, (void *) pBuf);
-+                UaceCensorImage(client, pDraw, &pPix->drawable, widthBytesLine, x, y + linesDone, width);
++                PixmapPtr pPix = GetScratchPixmapHeader(pDraw->pScreen, width, nlines, pDraw->depth, pDraw->bitsPerPixel, widthBytesLine, (void *) pBuf);
++                UaceCensorImage(client, pDraw, &pPix->drawable, x, y + linesDone, width, nlines);
 +                FreeScratchPixmapHeader(pPix);
 +            }
              WriteToClient(client, (int) (nlines * widthBytesLine), pBuf);


### PR DESCRIPTION
Fixed incorrect parameter passing in UaceCensorImage function call when creating secure regions. The function was being called with wrong parameter order and missing the nlines parameter, which prevented proper interception of XGetImage requests for screenshot protection.

The issue was in the XGetImage request handling where UaceCensorImage was called with parameters in wrong order: widthBytesLine was passed instead of height (nlines), and the nlines parameter was missing entirely. This caused the screenshot protection mechanism to fail for secure windows.

Log: Fixed screenshot protection for secure windows that was not working properly

Influence:
1. Test XGetImage requests on secure windows to verify protection works
2. Verify screenshot tools cannot capture protected window content
3. Test various window sizes and positions with screenshot protection
4. Verify normal screenshot functionality for non-secure windows remains unaffected
5. Test multiple simultaneous secure windows

fix: 修复UaceCensorImage调用参数错误

修复了创建安全区域时UaceCensorImage函数调用的参数传递错误。函数调用时
参数顺序错误且缺少nlines参数，这导致无法正确拦截XGetImage请求以实现截图
保护。

问题出现在XGetImage请求处理中，UaceCensorImage被以错误的参数顺序调用：传
入了widthBytesLine而不是高度(nlines)，并且完全缺少了nlines参数。这导致安 全窗口的截图保护机制失效。

Log: 修复了安全窗口截图保护功能无法正常工作的问题

Influence:
1. 测试安全窗口上的XGetImage请求，验证保护功能正常工作
2. 验证截图工具无法捕获受保护窗口内容
3. 使用截图保护测试各种窗口大小和位置
4. 验证非安全窗口的正常截图功能不受影响
5. 测试多个同时存在的安全窗口

PMS: BUG-338865
Change-Id: Ib3a8cfc0ff32ce152fdd389bd6f94d2a210c2434