### PR TITLE
fix: skip security area for minimized windows

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xorg-server (2:21.1.10-1deepin14) unstable; urgency=medium
+
+  * fix: skip security area for minimized windows
+
+ -- liuheng <liuhenga@uniontech.com>  Fri, 28 Nov 2025 18:03:44 +0800
+
 xorg-server (2:21.1.10-1deepin13) unstable; urgency=medium
 
   * fix: correct parameters for UaceCensorImage call

--- a/debian/patches/0001-feat-implement-screenshot-protection-for-secure-wind.patch
+++ b/debian/patches/0001-feat-implement-screenshot-protection-for-secure-wind.patch
@@ -98,7 +98,15 @@ Index: xorg-server/dix/dispatch.c
 ===================================================================
 --- xorg-server.orig/dix/dispatch.c
 +++ xorg-server/dix/dispatch.c
-@@ -143,6 +143,9 @@ int ProcInitialConnection();
+@@ -129,6 +129,7 @@ int ProcInitialConnection();
+ #include "xkbsrv.h"
+ #include "client.h"
+ #include "xfixesint.h"
++#include "propertyst.h"
+ 
+ #ifdef XSERVER_DTRACE
+ #include "registry.h"
+@@ -143,6 +144,9 @@ int ProcInitialConnection();
  #define BITCLEAR(buf, i) MASKWORD(buf, i) &= ~BITMASK(i)
  #define GETBIT(buf, i) (MASKWORD(buf, i) & BITMASK(i))
  
@@ -108,7 +116,7 @@ Index: xorg-server/dix/dispatch.c
  xConnSetupPrefix connSetupPrefix;
  
  PaddingInfo PixmapWidthPaddingInfo[33];
-@@ -150,6 +153,9 @@ PaddingInfo PixmapWidthPaddingInfo[33];
+@@ -150,6 +154,9 @@ PaddingInfo PixmapWidthPaddingInfo[33];
  static ClientPtr grabClient;
  static ClientPtr currentClient; /* Client for the request currently being dispatched */
  
@@ -118,7 +126,7 @@ Index: xorg-server/dix/dispatch.c
  #define GrabNone 0
  #define GrabActive 1
  static int grabState = GrabNone;
-@@ -1789,6 +1795,12 @@ ProcCopyArea(ClientPtr client)
+@@ -1789,6 +1796,12 @@ ProcCopyArea(ClientPtr client)
      pRgn = (*pGC->ops->CopyArea) (pSrc, pDst, pGC, stuff->srcX, stuff->srcY,
                                    stuff->width, stuff->height,
                                    stuff->dstX, stuff->dstY);
@@ -131,7 +139,7 @@ Index: xorg-server/dix/dispatch.c
      if (pGC->graphicsExposures) {
          SendGraphicsExpose(client, pRgn, stuff->dstDrawable, X_CopyArea, 0);
          if (pRgn)
-@@ -2134,6 +2146,323 @@ ProcPutImage(ClientPtr client)
+@@ -2134,6 +2147,354 @@ ProcPutImage(ClientPtr client)
      return Success;
  }
  
@@ -387,6 +395,34 @@ Index: xorg-server/dix/dispatch.c
 +    return failed;
 +}
 +
++#define WM_STATE_ATOM_NAME "WM_STATE"
++/*
++ * https://x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html
++ * The following table lists the WM_STATE.state values:
++ * State            Value
++ * WithdrawnState	0
++ * NormalState      1
++ * IconicState      3
++ */
++static Bool IsWindowInIconicState(WindowPtr pWin) {
++    static Atom wmState = None;
++    if (wmState == None) {
++        wmState = MakeAtom(WM_STATE_ATOM_NAME, strlen(WM_STATE_ATOM_NAME), TRUE);
++    }
++
++    PropertyPtr pProp;
++    for (pProp = wUserProps(pWin); pProp; pProp = pProp->next)
++        if (pProp->propertyName == wmState)
++            break;
++
++    if (pProp) {
++        CARD32* state = (CARD32 *)pProp->data;
++        return *state == 3;
++    }
++
++    return FALSE;
++}
++
 +void UaceCensorImage(ClientPtr client,
 +                DrawablePtr pSrc,
 +                DrawablePtr pDst,
@@ -402,20 +438,23 @@ Index: xorg-server/dix/dispatch.c
 +    GCPtr pScratchGC = GetScratchGC(pSrc->depth, pSrc->pScreen);
 +    for (int i = 0; i < protectedWindowCount; i++) {
 +        if (protectedWindowList[i]) {
-+            DrawablePtr pWindowDraw;
-+            const int nSuccess = dixLookupDrawable(&pWindowDraw,
-+                    protectedWindowList[i], client, 0, DixReadAccess);
++            WindowPtr pWindow;
++            const int rc = dixLookupWindow(&pWindow, protectedWindowList[i], client, DixReadAccess);
++            if (rc != Success) continue;
 +            ClientPtr pClient = clients[CLIENT_ID(protectedWindowList[i])];
 +            ClientPtr sClient = clients[CLIENT_ID(pSrc->id)];
 +            const pid_t xorgPid = getpid();
++
++            // not in IconicState or pSrc is protected window
++            Bool need = !IsWindowInIconicState(pWindow) || &(pWindow->drawable) == pSrc;
++
 +            // When the source is the protected window itself or the root window, intercept
-+            if (nSuccess == Success && pClient &&
-+                (pClient == sClient || xorgPid == sClient->clientIds->pid)) {
++            if (pClient && (pClient == sClient || xorgPid == sClient->clientIds->pid) && need) {
 +                xRectangle pRects;
-+                pRects.x = pWindowDraw->x - imageBox.x1;
-+                pRects.y = pWindowDraw->y - imageBox.y1;
-+                pRects.width = pWindowDraw->width;
-+                pRects.height = pWindowDraw->height;
++                pRects.x = pWindow->drawable.x - imageBox.x1;
++                pRects.y = pWindow->drawable.y - imageBox.y1;
++                pRects.width = pWindow->drawable.width;
++                pRects.height = pWindow->drawable.height;
 +                CreateCensorImage(client,
 +                    pScratchGC, pDst, pRects, bgPixel, lockPixel);
 +            }
@@ -455,7 +494,7 @@ Index: xorg-server/dix/dispatch.c
  static int
  DoGetImage(ClientPtr client, int format, Drawable drawable,
             int x, int y, int width, int height,
-@@ -2163,6 +2492,7 @@ DoGetImage(ClientPtr client, int format,
+@@ -2163,6 +2524,7 @@ DoGetImage(ClientPtr client, int format,
  
      relx = x;
      rely = y;
@@ -463,7 +502,7 @@ Index: xorg-server/dix/dispatch.c
  
      if (pDraw->type == DRAWABLE_WINDOW) {
          WindowPtr pWin = (WindowPtr) pDraw;
-@@ -2283,16 +2613,21 @@ DoGetImage(ClientPtr client, int format,
+@@ -2283,16 +2645,21 @@ DoGetImage(ClientPtr client, int format,
                                           width,
                                           nlines,
                                           format, planemask, (void *) pBuf);
@@ -514,3 +553,28 @@ Index: xorg-server/include/window.h
 +extern _X_EXPORT void RemoveProtectedWindow(Window window);
 +
  #endif                          /* WINDOW_H */
+Index: xorg-server/dix/window.c
+===================================================================
+--- xorg-server.orig/dix/window.c
++++ xorg-server/dix/window.c
+@@ -692,6 +692,20 @@ InitRootWindow(WindowPtr pWin)
+     /* We SHOULD check for an error value here XXX */
+     (*pScreen->ChangeWindowAttributes) (pWin, backFlag);
+ 
++#define DISPLAYJACK_MINIMIZED_SECURE_WINDOW_BY_XORG \
++    "_DISPLAYJACK_MINIMIZED_SECURE_WINDOW_BY_XORG"
++    static Atom atomSecure = None;
++
++    if (atomSecure == None) {
++        atomSecure = MakeAtom(DISPLAYJACK_MINIMIZED_SECURE_WINDOW_BY_XORG,
++                strlen(DISPLAYJACK_MINIMIZED_SECURE_WINDOW_BY_XORG), TRUE);
++    }
++
++    int data = 1;
++    dixChangeWindowProperty(serverClient, pWin,
++        atomSecure, XA_INTEGER, 8,
++                                PropModeReplace, 1, &data, TRUE);
++
+     MapWindow(pWin, serverClient);
+ }
+ 


### PR DESCRIPTION
1. Added WM_STATE property checking to detect window state
2. Implemented IsWindowInNormal function to check if window is in normal state (value 1)
3. Modified UaceCensorImage to skip creating security areas for non- normal windows unless they are protected windows
4. Added propertyst.h include for property handling
5. Updated window lookup to use dixLookupWindow instead of dixLookupDrawable for better window state access

This change addresses the issue where security areas were being drawn on minimized windows, which should not happen since minimized windows don't contain sensitive content. The solution checks the WM_STATE property according to ICCCM specifications and only creates security areas for windows in NormalState.

Influence:
1. Test screenshot protection on normal windows - security areas should appear
2. Test screenshot protection on minimized windows - security areas should not appear
3. Test screenshot protection on protected windows in any state - security areas should always appear
4. Verify window state detection works correctly for different window managers
5. Test with multiple windows in different states simultaneously

fix: 为非正常状态窗口跳过创建安全区域

1. 添加 WM_STATE 属性检查以检测窗口状态
2. 实现 IsWindowInNormal 函数检查窗口是否处于正常状态（值为1）
3. 修改 UaceCensorImage 函数，对于非正常状态的窗口跳过创建安全区域，除非 是受保护窗口
4. 添加 propertyst.h 头文件包含以支持属性处理
5. 更新窗口查找使用 dixLookupWindow 替代 dixLookupDrawable，以便更好地访 问窗口状态

此更改解决了最小化窗口时绘制安全区域的问题，因为最小化窗口不包含敏感内
容。解决方案根据 ICCCM 规范检查 WM_STATE 属性，仅对处于 NormalState 的窗 口创建安全区域。

Influence:
1. 测试正常窗口的截图保护 - 应显示安全区域
2. 测试最小化窗口的截图保护 - 不应显示安全区域
3. 测试任何状态下受保护窗口的截图保护 - 应始终显示安全区域
4. 验证窗口状态检测在不同窗口管理器下正常工作
5. 测试多个不同状态窗口同时存在的情况

PMS: BUG-340989
Change-Id: Ia6cf9dd17663bff3fb30d2895481ba8fde403a74