### PR TITLE
fix: add missing GBM library linkage to modesetting driver

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+xorg-server (2:21.1.16-1deepin2) unstable; urgency=medium
+
+  * fix: add missing GBM library linkage to modesetting driver
+    - Add $(GBM_CFLAGS) to AM_CFLAGS for gbm.h header path
+    - Add $(GBM_LIBS) to modesetting_drv_la_LIBADD for DT_NEEDED
+    - Fixes "undefined symbol: gbm_bo_get_plane_count" at runtime
+    - Only affects autotools build (meson build was correct)
+
+ -- lichenggang <lichenggang@uniontech.com>  Mon, 13 Jul 2026 13:15:00 +0800
+
 xorg-server (2:21.1.16-1deepin1) unstable; urgency=medium
 
   * Restore deepin patches on top of 21.1.16-1.3+deb13u2:

--- a/debian/patches/fix-modesetting-gbm-linkage.patch
+++ b/debian/patches/fix-modesetting-gbm-linkage.patch
@@ -1,0 +1,61 @@
+From: lichenggang <lichenggang@uniontech.com>
+Date: Mon, 13 Jul 2026 16:00:00 +0800
+Subject: fix: add missing GBM library linkage to modesetting driver
+
+modesetting_drv.so references gbm_bo_get_plane_count and other GBM
+symbols but the Makefile.am does not include $(GBM_LIBS) in LIBADD
+and $(GBM_CFLAGS) in AM_CFLAGS, causing undefined symbol errors at
+runtime when glamor is not loaded first.
+
+Signed-off-by: lichenggang <lichenggang@uniontech.com>
+---
+ hw/xfree86/drivers/modesetting/Makefile.am | 4 ++--
+ hw/xfree86/drivers/modesetting/Makefile.in | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/hw/xfree86/drivers/modesetting/Makefile.am b/hw/xfree86/drivers/modesetting/Makefile.am
+index 961c574..ce8a1d9 100644
+--- a/hw/xfree86/drivers/modesetting/Makefile.am
++++ b/hw/xfree86/drivers/modesetting/Makefile.am
+@@ -26,7 +26,7 @@
+
+ include $(top_srcdir)/manpages.am
+
+-AM_CFLAGS = $(DIX_CFLAGS) $(XORG_CFLAGS) $(LIBDRM_CFLAGS) $(UDEV_CFLAGS) $(CWARNFLAGS)
++AM_CFLAGS = $(DIX_CFLAGS) $(XORG_CFLAGS) $(LIBDRM_CFLAGS) $(UDEV_CFLAGS) $(GBM_CFLAGS) $(CWARNFLAGS)
+
+ AM_CPPFLAGS = \
+ 	$(XORG_INCS) \
+@@ -41,7 +41,7 @@ AM_CPPFLAGS = \
+
+ modesetting_drv_la_LTLIBRARIES = modesetting_drv.la
+ modesetting_drv_la_LDFLAGS = -module -avoid-version
+-modesetting_drv_la_LIBADD = $(UDEV_LIBS) $(DRM_LIBS)
++modesetting_drv_la_LIBADD = $(UDEV_LIBS) $(DRM_LIBS) $(GBM_LIBS)
+ modesetting_drv_ladir = @moduledir@/drivers
+
+ modesetting_drv_la_SOURCES = \
+diff --git a/hw/xfree86/drivers/modesetting/Makefile.in b/hw/xfree86/drivers/modesetting/Makefile.in
+index a410448..db85dfd 100644
+--- a/hw/xfree86/drivers/modesetting/Makefile.in
++++ b/hw/xfree86/drivers/modesetting/Makefile.in
+@@ -619,7 +619,7 @@ fileman_DATA = $(fileman_PRE:man=$(FILE_MAN_SUFFIX))
+ EXTRA_DIST = modesetting.man
+ CLEANFILES = $(driverman_DATA)
+ SUFFIXES = .$(APP_MAN_SUFFIX) .$(DRIVER_MAN_SUFFIX) .$(FILE_MAN_SUFFIX) .man
+-AM_CFLAGS = $(DIX_CFLAGS) $(XORG_CFLAGS) $(LIBDRM_CFLAGS) $(UDEV_CFLAGS) $(CWARNFLAGS)
++AM_CFLAGS = $(DIX_CFLAGS) $(XORG_CFLAGS) $(LIBDRM_CFLAGS) $(UDEV_CFLAGS) $(GBM_CFLAGS) $(CWARNFLAGS)
+ AM_CPPFLAGS = \
+ 	$(XORG_INCS) \
+ 	-I$(top_srcdir)/glamor \
+@@ -633,7 +633,7 @@ AM_CPPFLAGS = \
+
+ modesetting_drv_la_LTLIBRARIES = modesetting_drv.la
+ modesetting_drv_la_LDFLAGS = -module -avoid-version
+-modesetting_drv_la_LIBADD = $(UDEV_LIBS) $(DRM_LIBS)
++modesetting_drv_la_LIBADD = $(UDEV_LIBS) $(DRM_LIBS) $(GBM_LIBS)
+ modesetting_drv_ladir = @moduledir@/drivers
+ modesetting_drv_la_SOURCES = \
+ 	 dri2.c \
+--
+2.43.0

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -23,3 +23,4 @@ glamor-gles/1005-glamor-Fix-dual-blend-on-GLES3.patch
 0001-fix-randr-use-full-transform-for-CRTC-bounds-checking.patch
 0002-fix-randr-use-mode-space-coordinates-for-CRTC-bounds-checking.patch
 0003-fix-multi-screen-pointer-primary.patch
+fix-modesetting-gbm-linkage.patch


### PR DESCRIPTION
modesetting_drv.so references gbm_bo_get_plane_count and other GBM symbols but the Makefile.am does not include $(GBM_LIBS) in LIBADD, causing undefined symbol errors at runtime when glamor is not loaded first. This is a build system fix only - no code changes.

Log: Added missing $(GBM_LIBS) and $(GBM_CFLAGS) to modesetting Makefile

Influence:
1. Verify modesetting_drv.so loads without undefined symbol errors
2. Test Xorg with simpledrm and no arise driver
3. Verify no FBIOPUTCMAP errors in Xorg.0.log
4. Ensure glamor still works when available
5. Check no regression on other architectures (x86, arm, etc.)

fix: 修复 modesetting 驱动缺少 GBM 库链接的问题

modesetting_drv.so 引用了 gbm_bo_get_plane_count 等 GBM 符号， 但 Makefile.am 的 LIBADD 中没有包含 $(GBM_LIBS)，导致运行时
在 glamor 未先加载的情况下出现未定义符号错误。
仅构建系统修复，无代码改动。

Log: 在 modesetting Makefile 中添加缺失的 $(GBM_LIBS) 和 $(GBM_CFLAGS)

Influence:
1. 验证 modesetting_drv.so 加载不再出现未定义符号错误
2. 测试 Xorg 在 simpledrm 下无 arise 驱动时正常工作
3. 验证 Xorg.0.log 中无 FBIOPUTCMAP 错误
4. 确保 glamor 可用时仍正常工作
5. 检查其他架构（x86, arm 等）无回归

repo: xorg-server #topic-upgrade-20260622